### PR TITLE
Fix GUI imports and add star arrangement

### DIFF
--- a/mastercontroller.py
+++ b/mastercontroller.py
@@ -351,6 +351,33 @@ class MasterController:
                 self.pyramids.append(p)
                 self.export_pyramid_file(p)
 
+    def init_star_formation(self,
+                            count=6,
+                            radius=5.0,
+                            base_length=1.0,
+                            base_width=1.0,
+                            apex_height=2.0):
+        """Arrange pyramids around a circle on the XZ plane."""
+        self.clear_pyramids()
+        if count < 1:
+            return
+
+        angle_step = 2 * math.pi / count
+        for i in range(count):
+            ang = i * angle_step
+            x = math.cos(ang) * radius
+            z = math.sin(ang) * radius
+            p = Pyramid(
+                pyramid_id=i + 1,
+                num_corners=4,
+                base_length=base_length,
+                base_width=base_width,
+                apex_height=apex_height,
+            )
+            p.physics.position = np.array([x, 0.0, z], dtype=float)
+            self.pyramids.append(p)
+            self.export_pyramid_file(p)
+
     # ------------------------------------------------------------------------
     # MULTI-PYRAMID MANAGEMENT
     # ------------------------------------------------------------------------

--- a/pyramidGUI.py
+++ b/pyramidGUI.py
@@ -1,8 +1,3 @@
-Don Juan <chazkraiza@gmail.com>
-	
-Wed, Apr 2, 10:32 AM
-	
-to me
 #!/usr/bin/env python3
 """
 gui.py - A more refined, playful GUI bridging a 1950s phone switchboard aesthetic
@@ -26,7 +21,7 @@ Requires:
  - pyglet
  - PyOpenGL
  - numpy
- - master_controller.py and pyramid.py in the same folder
+ - mastercontroller.py and pyramid.py in the same folder
 """
 
 import pyglet
@@ -40,7 +35,7 @@ import numpy as np
 from OpenGL.GL import *
 from OpenGL.GLU import *
 
-from master_controller import (
+from mastercontroller import (
     MasterController, 
     PARTICLE_OFF, PARTICLE_LOW, PARTICLE_MEDIUM, PARTICLE_HEAVY,
     # Possibly also ANIMATION_WAVE_Y, ANIMATION_SPIN, ANIMATION_PULSE
@@ -209,7 +204,7 @@ class SwitchboardWindow(pyglet.window.Window):
 
     # ANIMATION
     def on_animation_pressed(self, lbl):
-        from master_controller import (ANIMATION_WAVE_Y, ANIMATION_SPIN, ANIMATION_PULSE)
+        from mastercontroller import (ANIMATION_WAVE_Y, ANIMATION_SPIN, ANIMATION_PULSE)
         if lbl=="WAVE":
             mc.set_animation_mode(ANIMATION_WAVE_Y)
             led_lamp.color= (0,255,0)   # green LED


### PR DESCRIPTION
## Summary
- clean stray header text from `pyramidGUI.py`
- import `mastercontroller` instead of non-existent `master_controller`
- implement missing `init_star_formation` in master controller

## Testing
- `python3 -m py_compile pyramidGUI.py mastercontroller.py pyramid.py`
- `python3 mastercontroller.py` *(fails: NoSuchDisplayException)*

------
https://chatgpt.com/codex/tasks/task_e_68403d111e7c83229826a6c6fab2ab86