### PR TITLE
Restore Rainbow Starburst and implement audio reactivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+venv/
+
+# Runtime-generated scene definitions.  The application keeps this set in sync
+# with the active switchboard formation.
+Pyramids/pyramid_*.txt
+
+*.log

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The switchboard defaults produce these managed file counts:
 - Raw samples stay in bounded memory buffers and are discarded after analysis. The application does not record, transcribe, upload, or transmit audio.
 - PortAudio callbacks only copy samples. Analyzer threads publish immutable feature frames; only the pyglet render thread changes visual state.
 - System output and microphone use separate sample rates, noise floors, normalization, and analyzers. They are combined at the feature level instead of mixing unsynchronized PCM.
+- The analyzer publishes eight musical macro bands plus a 48-channel logarithmic spectrum. Every generated pyramid receives a unique center frequency from 35 Hz to 16 kHz, a distinct bandwidth, harmonic/subharmonic sensitivity, response rate, damping ratio, and phase.
+- A fixed-step resonator bank turns those acoustic identities into coupled spring motion beneath every creative program. A single tone excites a local minority of pyramids, chords create multiple clusters, and broadband sound spreads across overlapping voices.
 - Endpoint loss degrades to an unavailable status while the renderer continues. A monitor retries the selected endpoint without blocking a frame.
 - Every program returns exactly to authored home geometry after 1.5 seconds of silence. Reactive state is never written into pyramid exports.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rainbow Starburst
 
-This repository contains a pyglet + PyOpenGL visualization driven by `mastercontroller.py` and a switchboard-style UI in `pyramidGUI.py`.
+This repository contains a pyglet + PyOpenGL visualization driven by `mastercontroller.py` and a tactile switchboard-style UI in `pyramidGUI.py`.
 
 ## Prerequisites
 
@@ -32,23 +32,46 @@ The interactive entry point is the GUI module:
 python pyramidGUI.py
 ```
 
-This launches two pyglet windows:
+This launches two pyglet windows and immediately routes the animated **Star** formation so the stage is never empty:
 
-1. **Switchboard console** &mdash; buttons for changing arrangements, particle density, and animation modes along with knobs to tweak wave strength and globe subdivisions.
-2. **3D visualization** &mdash; renders the active pyramid arrangement and a rainbow path while continuously calling `MasterController.update` for physics and export scheduling.
+1. **Switchboard console** &mdash; illuminated controls for arrangements, particle gain, and animation programs plus bounded knobs for wave strength and globe detail.
+2. **3D visualization** &mdash; renders the active formation, its animated rainbow signal path, a depth grid, and interactive particle bursts.
 
 Arrange both windows so they stay visible; closing either one exits the process.
 
 ## Controls
 
-- **Arrangements**: Choose Edge2Edge, SpikeSphere, Grid, Star, or Globe to rebuild the scene. Globe uses the subdivision knob and turntable to adjust density and apex offset respectively.
+- **Arrangements**: Choose Edge2Edge, SpikeSphere, Grid, Star, or Globe to rebuild the scene. SpikeSphere spaces square pyramids over a sphere. Star is a full joined SpikeSphere: its triangular bases share edges across an icosahedral core and all apexes point outward. Globe detail is safely bounded to subdivisions 0&ndash;3 (20&ndash;1,280 faces), and the turntable sets apex offset.
 - **Particle Modes**: OFF/LOW/MEDIUM/HEAVY toggle burst intensity. Modes are handled by `MasterController.set_particle_mode`.
-- **Animations**: WAVE/SPIN/PULSE/NONE set the animation mode. The LED indicator above the speaker rectangle lights up in green/red/blue depending on the active mode.
-- **Knobs**: Drag WaveAmp to scale wave motion on the Y axis for pyramids that enable it; drag GlobeSubdiv to change the next globe arrangement density. Spin the turntable disc to update the apex offset before rebuilding the globe.
+- **Animations**: WAVE/SPIN/PULSE/NONE are mutually exclusive motion programs. The signal monitor changes color with the active program.
+- **Knobs**: Drag Wave Amplitude to scale non-accumulating wave motion; drag Globe Detail to set the next globe density. Spin Apex Offset before rebuilding the globe.
+- **Viewport**: Click the visualization to emit the selected particle burst, scroll to move the camera, press Space to pause, or press R to reset the trace and camera.
+- **Keyboard**: Keys 1&ndash;5 route the five formations; Escape closes both windows.
 
-Mouse interactions are bound inside the UI window; the visualization window responds to expose events and automatically spins the camera. Use the console output for feedback on knob/arrangement changes.
+Closing either window exits the complete application.
 
 ## Data output
 
-Each time the controller creates pyramids it writes their definitions to `Pyramids/` using the deferred export queue configured in `MasterController`. You can disable exporting or change throughput programmatically before starting intensive sessions.
+Each arrangement writes its definitions to `Pyramids/`. After every switch, files matching `pyramid_<integer>.txt` mirror the active formation exactly: stale higher IDs are removed and the current IDs are rewritten. Other files and subdirectories are preserved. Exporting can still be disabled or redirected programmatically through `MasterController`.
 
+The switchboard defaults produce these managed file counts:
+
+| Formation | Files |
+| --- | ---: |
+| Edge2Edge | 7 |
+| SpikeSphere | 24 |
+| Grid | 20 |
+| Star | 80 |
+| Globe | `20 × 4^detail` (20, 80, 320, or 1,280) |
+
+## Tests
+
+Run the geometry, animation, and export synchronization checks with:
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+## Next: local audio reactivity
+
+The implementation-ready plan for Windows system-output capture, microphone input, per-pyramid modulation architecture, and seven creative reactive programs is in [docs/AUDIO_REACTIVE_ROADMAP.md](docs/AUDIO_REACTIVE_ROADMAP.md).

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ This repository contains a pyglet + PyOpenGL visualization driven by `mastercont
 
 ## Prerequisites
 
-The project targets Python 3.9+ and depends on:
+The project targets Python 3.10+ and depends on:
 
 - [numpy](https://numpy.org/)
 - [pyglet](https://pyglet.org/)
 - [PyOpenGL](http://pyopengl.sourceforge.net/)
+- [PyAudioWPatch](https://github.com/s0d3s/PyAudioWPatch) on Windows for WASAPI loopback and microphone capture
 
 Install them into your active environment (virtualenv or system Python):
 
@@ -16,11 +17,8 @@ Install them into your active environment (virtualenv or system Python):
 pip install -r requirements.txt
 ```
 
-or directly:
-
-```bash
-pip install numpy pyglet PyOpenGL
-```
+`requirements.txt` installs the Windows audio backend conditionally, so the
+same installation command remains safe on other operating systems.
 
 On Linux you may also need system OpenGL drivers and an X11 session (or Wayland with XWayland) so pyglet can create windows.
 
@@ -34,17 +32,21 @@ python pyramidGUI.py
 
 This launches two pyglet windows and immediately routes the animated **Star** formation so the stage is never empty:
 
-1. **Switchboard console** &mdash; illuminated controls for arrangements, particle gain, and animation programs plus bounded knobs for wave strength and globe detail.
-2. **3D visualization** &mdash; renders the active formation, its animated rainbow signal path, a depth grid, and interactive particle bursts.
+1. **Switchboard console** &mdash; formation routing, local audio sources, seven audio programs, manual motion, particle limits, response controls, endpoint selection, and live diagnostics.
+2. **3D visualization** &mdash; renders immutable home geometry plus bounded per-pyramid audio modulation, a moving rainbow signal path, a depth grid, and particles.
 
 Arrange both windows so they stay visible; closing either one exits the process.
 
 ## Controls
 
 - **Arrangements**: Choose Edge2Edge, SpikeSphere, Grid, Star, or Globe to rebuild the scene. SpikeSphere spaces square pyramids over a sphere. Star is a full joined SpikeSphere: its triangular bases share edges across an icosahedral core and all apexes point outward. Globe detail is safely bounded to subdivisions 0&ndash;3 (20&ndash;1,280 faces), and the turntable sets apex offset.
-- **Particle Modes**: OFF/LOW/MEDIUM/HEAVY toggle burst intensity. Modes are handled by `MasterController.set_particle_mode`.
-- **Animations**: WAVE/SPIN/PULSE/NONE are mutually exclusive motion programs. The signal monitor changes color with the active program.
-- **Knobs**: Drag Wave Amplitude to scale non-accumulating wave motion; drag Globe Detail to set the next globe density. Spin Apex Offset before rebuilding the globe.
+- **Audio sources**: OFF, SYSTEM, MIC, BOTH, and DEMO. Audio always starts OFF. SYSTEM follows a selected Windows WASAPI loopback endpoint, MIC opens the selected input, BOTH analyzes two independent streams, and DEMO generates a deterministic private test signal.
+- **Audio programs**: CROWN, BLOOM, ORBIT, CINEMA, RADAR, RELAY, and AURORA. Each program controls individual pyramid tips, routing, line response, and particles through the same bounded render-state contract.
+- **Manual animations**: WAVE/SPIN/PULSE/NONE remain available and mutually exclusive. Selecting manual motion stops audio capture and immediately returns reactive geometry home.
+- **Particle modes**: OFF/LOW/MEDIUM/HEAVY control click-burst intensity. Program particles remain globally capped at 2,000.
+- **Response controls**: Sensitivity controls audio gain (and manual wave depth), Reactivity controls envelope speed, Globe Detail sets the next globe density, and Apex Offset changes the next globe's tip height.
+- **Endpoint controls**: NEXT SYSTEM and NEXT MIC cycle the discovered endpoints. Selected identifiers and response preferences are stored in the current user's local application-data folder; audio never auto-starts on launch.
+- **Reduced motion**: Scales transient displacement, rotation, and particle output while preserving analysis and program routing.
 - **Viewport**: Click the visualization to emit the selected particle burst, scroll to move the camera, press Space to pause, or press R to reset the trace and camera.
 - **Keyboard**: Keys 1&ndash;5 route the five formations; Escape closes both windows.
 
@@ -64,14 +66,32 @@ The switchboard defaults produce these managed file counts:
 | Star | 80 |
 | Globe | `20 × 4^detail` (20, 80, 320, or 1,280) |
 
+## Audio architecture and privacy
+
+- Raw samples stay in bounded memory buffers and are discarded after analysis. The application does not record, transcribe, upload, or transmit audio.
+- PortAudio callbacks only copy samples. Analyzer threads publish immutable feature frames; only the pyglet render thread changes visual state.
+- System output and microphone use separate sample rates, noise floors, normalization, and analyzers. They are combined at the feature level instead of mixing unsynchronized PCM.
+- Endpoint loss degrades to an unavailable status while the renderer continues. A monitor retries the selected endpoint without blocking a frame.
+- Every program returns exactly to authored home geometry after 1.5 seconds of silence. Reactive state is never written into pyramid exports.
+
+The detailed algorithms, mappings, controls, and acceptance criteria are in
+[docs/AUDIO_REACTIVE_ROADMAP.md](docs/AUDIO_REACTIVE_ROADMAP.md).
+
 ## Tests
 
-Run the geometry, animation, and export synchronization checks with:
+Run the complete geometry, audio-feature, animation, lifecycle, and export suite with:
 
 ```bash
 python -m unittest discover -s tests -v
 ```
 
-## Next: local audio reactivity
+The deterministic suite uses generated signals only; it never captures test audio
+from the local computer.
 
-The implementation-ready plan for Windows system-output capture, microphone input, per-pyramid modulation architecture, and seven creative reactive programs is in [docs/AUDIO_REACTIVE_ROADMAP.md](docs/AUDIO_REACTIVE_ROADMAP.md).
+List endpoints or inspect live normalized levels without opening the GUI:
+
+```bash
+python -m audio.diagnostic --list
+python -m audio.diagnostic --source both --seconds 10
+python -m audio.diagnostic --source demo --seconds 5
+```

--- a/animations/__init__.py
+++ b/animations/__init__.py
@@ -1,0 +1,6 @@
+"""Per-pyramid audio animation programs and render-state composition."""
+
+from .director import AnimationDirector, PROGRAM_NAMES
+from .render import apply_render_state
+
+__all__ = ["AnimationDirector", "PROGRAM_NAMES", "apply_render_state"]

--- a/animations/base.py
+++ b/animations/base.py
@@ -1,0 +1,173 @@
+"""Shared animation contracts and bounded vector state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+
+import numpy as np
+
+from audio.features import AudioFeatureFrame
+
+
+@dataclass
+class RenderStateBatch:
+    radial_offset: np.ndarray
+    apex_scale: np.ndarray
+    uniform_scale: np.ndarray
+    rotation_offset: np.ndarray
+    line_alpha: np.ndarray
+    line_width: np.ndarray
+    accent_mix: np.ndarray
+    accent_hue: np.ndarray
+    particle_rate: np.ndarray
+    route: tuple[int, ...] = field(default_factory=tuple)
+    route_energy: float = 0.0
+
+    @classmethod
+    def identity(cls, count: int) -> "RenderStateBatch":
+        n = max(0, int(count))
+        return cls(
+            radial_offset=np.zeros(n, dtype=float),
+            apex_scale=np.ones(n, dtype=float),
+            uniform_scale=np.ones(n, dtype=float),
+            rotation_offset=np.zeros((n, 3), dtype=float),
+            line_alpha=np.full(n, 0.68, dtype=float),
+            line_width=np.full(n, 1.5, dtype=float),
+            accent_mix=np.zeros(n, dtype=float),
+            accent_hue=np.zeros(n, dtype=float),
+            particle_rate=np.zeros(n, dtype=float),
+        )
+
+    def copy(self) -> "RenderStateBatch":
+        return RenderStateBatch(
+            self.radial_offset.copy(),
+            self.apex_scale.copy(),
+            self.uniform_scale.copy(),
+            self.rotation_offset.copy(),
+            self.line_alpha.copy(),
+            self.line_width.copy(),
+            self.accent_mix.copy(),
+            self.accent_hue.copy(),
+            self.particle_rate.copy(),
+            tuple(self.route),
+            float(self.route_energy),
+        )
+
+    def clamp(self, core_radius: float, reduced_motion=False) -> "RenderStateBatch":
+        motion = 0.32 if reduced_motion else 1.0
+        self.radial_offset[:] = np.clip(self.radial_offset * motion, -0.35 * core_radius, 0.35 * core_radius)
+        self.apex_scale[:] = 1.0 + np.clip((self.apex_scale - 1.0) * motion, -0.45, 0.9)
+        self.uniform_scale[:] = 1.0 + np.clip((self.uniform_scale - 1.0) * motion, -0.18, 0.22)
+        self.rotation_offset[:] = np.clip(self.rotation_offset * motion, -18.0, 18.0)
+        self.line_alpha[:] = np.clip(self.line_alpha, 0.2, 1.0)
+        self.line_width[:] = np.clip(self.line_width, 1.0, 4.5)
+        self.accent_mix[:] = np.clip(self.accent_mix, 0.0, 0.88)
+        self.accent_hue[:] = np.mod(self.accent_hue, 1.0)
+        self.particle_rate[:] = np.clip(self.particle_rate * motion, 0.0, 30.0)
+        self.route_energy = float(np.clip(self.route_energy, 0.0, 1.0))
+        return self
+
+    @classmethod
+    def blend(cls, first: "RenderStateBatch", second: "RenderStateBatch", amount: float) -> "RenderStateBatch":
+        t = float(np.clip(amount, 0.0, 1.0))
+
+        def mix(a, b):
+            return a + (b - a) * t
+
+        return cls(
+            mix(first.radial_offset, second.radial_offset),
+            mix(first.apex_scale, second.apex_scale),
+            mix(first.uniform_scale, second.uniform_scale),
+            mix(first.rotation_offset, second.rotation_offset),
+            mix(first.line_alpha, second.line_alpha),
+            mix(first.line_width, second.line_width),
+            mix(first.accent_mix, second.accent_mix),
+            mix(first.accent_hue, second.accent_hue),
+            mix(first.particle_rate, second.particle_rate),
+            second.route if t >= 0.5 else first.route,
+            float(first.route_energy + (second.route_energy - first.route_energy) * t),
+        )
+
+
+@dataclass(frozen=True)
+class CombinedFeatures:
+    active: bool
+    rms: float
+    peak: float
+    bands: np.ndarray
+    centroid: float
+    flux: float
+    onset: bool
+    beat_phase: float
+    tempo_confidence: float
+    stereo_balance: float
+    stereo_width: float
+    pitch_classes: np.ndarray
+    pitch_confidence: float
+    octave_position: float
+    flatness: float
+    low_flux: float
+    high_flux: float
+
+
+def combine_features(frame: AudioFeatureFrame) -> CombinedFeatures:
+    system, microphone = frame.system, frame.microphone
+    weights = np.array([system.rms, microphone.rms], dtype=float)
+    total = float(weights.sum())
+    if total <= 1e-9:
+        weights[:] = 0.5
+    else:
+        weights /= total
+    bands = np.maximum(np.asarray(system.bands), np.asarray(microphone.bands))
+    pitches = weights[0] * np.asarray(system.pitch_classes) + weights[1] * np.asarray(microphone.pitch_classes)
+    dominant = system if system.rms >= microphone.rms else microphone
+    return CombinedFeatures(
+        active=system.active or microphone.active,
+        rms=max(system.rms, microphone.rms),
+        peak=max(system.peak, microphone.peak),
+        bands=bands,
+        centroid=float(weights[0] * system.centroid + weights[1] * microphone.centroid),
+        flux=max(system.flux, microphone.flux),
+        onset=system.onset or microphone.onset,
+        beat_phase=dominant.beat_phase,
+        tempo_confidence=max(system.tempo_confidence, microphone.tempo_confidence),
+        stereo_balance=dominant.stereo_balance,
+        stereo_width=dominant.stereo_width,
+        pitch_classes=pitches,
+        pitch_confidence=max(system.pitch_confidence, microphone.pitch_confidence),
+        octave_position=float(weights[0] * system.octave_position + weights[1] * microphone.octave_position),
+        flatness=float(weights[0] * system.spectral_flatness + weights[1] * microphone.spectral_flatness),
+        low_flux=max(system.low_flux, microphone.low_flux),
+        high_flux=max(system.high_flux, microphone.high_flux),
+    )
+
+
+def smooth(current: np.ndarray, target: np.ndarray, dt: float, attack=0.055, release=0.32) -> None:
+    rising = target > current
+    attack_alpha = 1.0 - math.exp(-max(0.0, dt) / max(1e-4, attack))
+    release_alpha = 1.0 - math.exp(-max(0.0, dt) / max(1e-4, release))
+    alpha = np.where(rising, attack_alpha, release_alpha)
+    current += (target - current) * alpha
+
+
+class AudioAnimation:
+    name = "BASE"
+
+    def __init__(self, topology):
+        self.topology = topology
+        self.state = RenderStateBatch.identity(topology.count)
+        self.last_sequence = -1
+
+    def reset(self) -> None:
+        self.state = RenderStateBatch.identity(self.topology.count)
+        self.last_sequence = -1
+
+    def is_new_frame(self, frame: AudioFeatureFrame) -> bool:
+        if frame.sequence == self.last_sequence:
+            return False
+        self.last_sequence = frame.sequence
+        return True
+
+    def update(self, dt, now, frame, gain=1.0, reactivity=1.0) -> RenderStateBatch:
+        raise NotImplementedError

--- a/animations/base.py
+++ b/animations/base.py
@@ -96,6 +96,7 @@ class CombinedFeatures:
     rms: float
     peak: float
     bands: np.ndarray
+    spectrum: np.ndarray
     centroid: float
     flux: float
     onset: bool
@@ -120,6 +121,7 @@ def combine_features(frame: AudioFeatureFrame) -> CombinedFeatures:
     else:
         weights /= total
     bands = np.maximum(np.asarray(system.bands), np.asarray(microphone.bands))
+    spectrum = np.maximum(np.asarray(system.spectrum), np.asarray(microphone.spectrum))
     pitches = weights[0] * np.asarray(system.pitch_classes) + weights[1] * np.asarray(microphone.pitch_classes)
     dominant = system if system.rms >= microphone.rms else microphone
     return CombinedFeatures(
@@ -127,6 +129,7 @@ def combine_features(frame: AudioFeatureFrame) -> CombinedFeatures:
         rms=max(system.rms, microphone.rms),
         peak=max(system.peak, microphone.peak),
         bands=bands,
+        spectrum=spectrum,
         centroid=float(weights[0] * system.centroid + weights[1] * microphone.centroid),
         flux=max(system.flux, microphone.flux),
         onset=system.onset or microphone.onset,

--- a/animations/beat_bloom.py
+++ b/animations/beat_bloom.py
@@ -1,0 +1,61 @@
+"""Beat Bloom: kick bloom, snare graph ring, and hat parity shimmer."""
+
+import math
+
+import numpy as np
+
+from .base import AudioAnimation, combine_features
+
+
+class BeatBloom(AudioAnimation):
+    name = "BLOOM"
+
+    def __init__(self, topology):
+        super().__init__(topology)
+        self.kick = 0.0
+        self.hat = 0.0
+        self.ring_age = 99.0
+        self.ring_seed = 0
+
+    def reset(self):
+        super().reset()
+        self.kick = self.hat = 0.0
+        self.ring_age = 99.0
+
+    def update(self, dt, now, frame, gain=1.0, reactivity=1.0):
+        feature = combine_features(frame)
+        self.kick *= math.exp(-dt / (0.24 / reactivity))
+        self.hat *= math.exp(-dt / (0.075 / reactivity))
+        self.ring_age += dt
+        if self.is_new_frame(frame) and feature.onset:
+            low = float(np.mean(feature.bands[:2])) * (0.5 + 0.5 * feature.low_flux)
+            high = float(np.mean(feature.bands[6:])) * (0.4 + 0.6 * feature.high_flux)
+            middle = float(np.mean(feature.bands[2:6]))
+            if low >= max(high * 0.7, middle * 0.55):
+                self.kick = max(self.kick, np.clip(low * gain * 1.5, 0.0, 1.0))
+            if middle + high * 0.65 > low * 0.8:
+                self.ring_age = 0.0
+                self.ring_seed = (frame.sequence * 17) % max(1, self.topology.count)
+            if high > 0.12:
+                self.hat = max(self.hat, np.clip(high * gain * 1.8, 0.0, 1.0))
+
+        if self.topology.count:
+            distance = self.topology.distances_from(self.ring_seed).astype(float)
+            speed = 28.0 * reactivity
+            ring_position = self.ring_age * speed
+            ring = np.exp(-0.5 * np.square((distance - ring_position) / 0.8))
+        else:
+            distance = ring = np.zeros(0)
+        parity = (self.topology.parity == int((now * 22.0) % 2)).astype(float)
+        breath = 0.025 * feature.tempo_confidence * math.sin(feature.beat_phase * 2.0 * math.pi)
+        self.state.uniform_scale[:] = 1.0 + breath + 0.055 * self.kick
+        self.state.apex_scale[:] = 1.0 + 0.55 * self.kick + 0.46 * ring + 0.18 * self.hat * parity
+        self.state.radial_offset[:] = self.topology.core_radius * (0.035 * self.kick + 0.08 * ring)
+        self.state.line_alpha[:] = 0.64 + 0.3 * np.maximum(ring, self.kick)
+        self.state.line_width[:] = 1.4 + 1.8 * np.maximum(ring, self.hat * parity)
+        self.state.accent_mix[:] = np.clip(0.78 * ring + 0.35 * self.hat * parity, 0.0, 0.85)
+        self.state.accent_hue[:] = np.mod(distance / max(1.0, distance.max(initial=1.0)) + feature.beat_phase, 1.0)
+        self.state.particle_rate[:] = ring * max(0.0, feature.flux - 0.5) * 12.0
+        self.state.route = tuple(np.argsort(distance).tolist()) if len(distance) else ()
+        self.state.route_energy = float(np.clip(max(self.kick, self.hat, feature.flux), 0.0, 1.0))
+        return self.state

--- a/animations/cinematic_weather.py
+++ b/animations/cinematic_weather.py
@@ -1,0 +1,66 @@
+"""Cinematic Weather: multiscale atmosphere, presence, swell, and impact rings."""
+
+import math
+
+import numpy as np
+
+from .base import AudioAnimation, combine_features, smooth
+
+
+class CinematicWeather(AudioAnimation):
+    name = "CINEMA"
+
+    def __init__(self, topology):
+        super().__init__(topology)
+        self.short = 0.0
+        self.long = 0.0
+        self.previous_long = 0.0
+        self.swell = 0.0
+        self.impact_age = 99.0
+        self.impact_seed = 0
+        self.energy = np.zeros(topology.count)
+
+    def reset(self):
+        super().reset()
+        self.short = self.long = self.previous_long = self.swell = 0.0
+        self.impact_age = 99.0
+        self.energy[:] = 0.0
+
+    def update(self, dt, now, frame, gain=1.0, reactivity=1.0):
+        feature = combine_features(frame)
+        short_alpha = 1.0 - math.exp(-dt / 0.16)
+        long_seconds = 1.5 if feature.rms >= self.long else 0.42
+        long_alpha = 1.0 - math.exp(-dt / long_seconds)
+        self.short += (feature.rms - self.short) * short_alpha
+        self.previous_long = self.long
+        self.long += (feature.rms - self.long) * long_alpha
+        slope = (self.long - self.previous_long) / max(dt, 1e-5)
+        self.swell += (max(0.0, slope * 2.5) - self.swell) * (1.0 - math.exp(-dt / 1.2))
+        self.impact_age += dt
+        if self.is_new_frame(frame) and feature.onset and feature.low_flux > 0.45 and self.impact_age > 0.32:
+            target_azimuth = feature.stereo_balance * math.pi * 0.5
+            target = np.array([math.cos(target_azimuth), -0.45, math.sin(target_azimuth)])
+            target /= np.linalg.norm(target)
+            self.impact_seed = int(np.argmax(self.topology.normals @ target)) if self.topology.count else 0
+            self.impact_age = 0.0
+        distance = self.topology.distances_from(self.impact_seed).astype(float) if self.topology.count else np.zeros(0)
+        ring_position = self.impact_age * 13.0 * reactivity
+        impact = np.exp(-0.5 * np.square((distance - ring_position) / 1.25)) * max(0.0, 1.0 - self.impact_age / 1.4)
+        latitude_target = (feature.centroid - 0.5) * 1.3
+        weather = np.exp(-0.5 * np.square((self.topology.latitude - latitude_target) / 0.55)) if self.topology.count else np.zeros(0)
+        presence = float(np.mean(feature.bands[2:6]))
+        equator = np.exp(-np.square(self.topology.latitude / 0.34)) if self.topology.count else np.zeros(0)
+        target_energy = np.clip((self.long * 0.55 * weather + presence * 0.7 * equator + impact) * gain, 0.0, 1.0)
+        smooth(self.energy, target_energy, dt, attack=0.12 / reactivity, release=0.48 / reactivity)
+        breath = math.sin(now * 0.7) * 0.06 * self.long
+        self.state.uniform_scale[:] = 1.0 + breath + 0.04 * self.swell
+        self.state.apex_scale[:] = 1.0 + 0.42 * self.energy + 0.48 * impact
+        self.state.radial_offset[:] = self.topology.core_radius * (0.055 * self.energy + 0.13 * impact)
+        self.state.line_alpha[:] = 0.6 + 0.37 * self.energy
+        self.state.line_width[:] = 1.35 + 1.8 * self.energy
+        self.state.accent_mix[:] = np.clip(0.34 * weather * self.long + 0.78 * impact, 0.0, 0.84)
+        self.state.accent_hue[:] = np.mod((self.topology.azimuth + math.pi) / (2.0 * math.pi) + feature.centroid * 0.3, 1.0)
+        self.state.particle_rate[:] = impact * feature.low_flux * 10.0
+        self.state.route = tuple(np.argsort(distance).tolist()) if len(distance) else ()
+        self.state.route_energy = float(np.clip(max(self.long * 0.6, impact.max(initial=0.0)), 0.0, 1.0))
+        return self.state

--- a/animations/conversation_orbit.py
+++ b/animations/conversation_orbit.py
@@ -1,0 +1,67 @@
+"""Conversation Orbit: separate system and microphone activity hemispheres."""
+
+import math
+
+import numpy as np
+
+from .base import AudioAnimation, smooth
+
+
+class ConversationOrbit(AudioAnimation):
+    name = "ORBIT"
+
+    def __init__(self, topology):
+        super().__init__(topology)
+        x = topology.normals[:, 0] if topology.count else np.zeros(0)
+        self.system_weight = np.clip(0.15 + 0.85 * (x + 1.0) * 0.5, 0.15, 1.0)
+        self.mic_weight = np.clip(0.15 + 0.85 * (1.0 - x) * 0.5, 0.15, 1.0)
+        self.energy = np.zeros(topology.count)
+        self.last_active = "quiet"
+        self.handoff_age = 99.0
+        self.handoff_route = ()
+        self.system_node = int(np.argmax(x)) if topology.count else 0
+        self.mic_node = int(np.argmin(x)) if topology.count else 0
+
+    def reset(self):
+        super().reset()
+        self.energy[:] = 0.0
+        self.last_active = "quiet"
+        self.handoff_age = 99.0
+        self.handoff_route = ()
+
+    def update(self, dt, now, frame, gain=1.0, reactivity=1.0):
+        system = frame.system.rms if frame.system.active else 0.0
+        microphone = frame.microphone.rms if frame.microphone.active else 0.0
+        target = np.clip((system * self.system_weight + microphone * self.mic_weight) * gain, 0.0, 1.0)
+        smooth(self.energy, target, dt, attack=0.07 / reactivity, release=0.42 / reactivity)
+        current = "both" if system > 0.08 and microphone > 0.08 else (
+            "system" if system > microphone and system > 0.08 else "microphone" if microphone > 0.08 else "quiet"
+        )
+        if self.is_new_frame(frame) and current in ("system", "microphone") and self.last_active in ("system", "microphone") and current != self.last_active:
+            start = self.system_node if self.last_active == "system" else self.mic_node
+            goal = self.system_node if current == "system" else self.mic_node
+            self.handoff_route = self.topology.shortest_path(start, goal)
+            self.handoff_age = 0.0
+        if current != "quiet":
+            self.last_active = current
+        self.handoff_age += dt
+        equator = np.exp(-np.square(self.topology.latitude / 0.32)) if self.topology.count else np.zeros(0)
+        overlap = min(system, microphone)
+        route_energy = max(0.0, 1.0 - self.handoff_age / 0.7)
+        route_mask = np.zeros(self.topology.count)
+        if self.handoff_route and route_energy > 0.0:
+            progress = self.handoff_age / 0.7 * len(self.handoff_route)
+            for index, node in enumerate(self.handoff_route):
+                route_mask[node] = math.exp(-0.5 * ((index - progress) / 1.4) ** 2)
+        self.state.apex_scale[:] = 1.0 + 0.55 * self.energy + 0.28 * overlap * equator
+        self.state.radial_offset[:] = self.topology.core_radius * (0.08 * self.energy + 0.08 * route_mask)
+        self.state.uniform_scale[:] = 1.0 + 0.035 * overlap
+        self.state.rotation_offset[:, 1] = overlap * math.sin(now * 0.8) * 5.0
+        self.state.line_alpha[:] = 0.62 + 0.34 * self.energy
+        self.state.line_width[:] = 1.4 + 1.5 * self.energy
+        self.state.accent_mix[:] = np.clip(0.45 * self.energy + 0.7 * route_mask, 0.0, 0.85)
+        self.state.accent_hue[:] = np.where(self.topology.normals[:, 0] >= 0.0, 0.56, 0.03)
+        self.state.particle_rate[:] = np.where((system + microphone) > 1.4, equator * 2.0, 0.0)
+        self.state.route = self.handoff_route
+        self.state.route_energy = float(route_energy)
+        return self.state

--- a/animations/director.py
+++ b/animations/director.py
@@ -1,0 +1,110 @@
+"""Lifecycle, crossfades, bounds, and formation changes for all programs."""
+
+from __future__ import annotations
+
+from audio.features import AudioFeatureFrame
+
+from .base import RenderStateBatch
+from .beat_bloom import BeatBloom
+from .cinematic_weather import CinematicWeather
+from .conversation_orbit import ConversationOrbit
+from .game_radar import GameRadar
+from .harmonic_aurora import HarmonicAurora
+from .signal_relay import SignalRelay
+from .spectrum_crown import SpectrumCrown
+from .topology import FormationTopology
+
+
+PROGRAM_TYPES = {
+    "CROWN": SpectrumCrown,
+    "BLOOM": BeatBloom,
+    "ORBIT": ConversationOrbit,
+    "CINEMA": CinematicWeather,
+    "RADAR": GameRadar,
+    "RELAY": SignalRelay,
+    "AURORA": HarmonicAurora,
+}
+PROGRAM_NAMES = tuple(PROGRAM_TYPES)
+
+
+class AnimationDirector:
+    def __init__(self, pyramids=()):
+        self.topology = FormationTopology(pyramids)
+        self.programs = {name: program_type(self.topology) for name, program_type in PROGRAM_TYPES.items()}
+        self.active_name: str | None = None
+        self.output = RenderStateBatch.identity(self.topology.count)
+        self._transition_from = self.output.copy()
+        self._transition_elapsed = 0.25
+        self.transition_seconds = 0.25
+        self.sensitivity = 1.0
+        self.reactivity = 1.0
+        self.reduced_motion = False
+        self._silence_elapsed = 0.0
+
+    @property
+    def active(self) -> bool:
+        return self.active_name is not None
+
+    def set_formation(self, pyramids) -> None:
+        selected = self.active_name
+        self.topology = FormationTopology(pyramids)
+        self.programs = {name: program_type(self.topology) for name, program_type in PROGRAM_TYPES.items()}
+        self.output = RenderStateBatch.identity(self.topology.count)
+        self._transition_from = self.output.copy()
+        self._transition_elapsed = self.transition_seconds
+        self.active_name = selected if selected in self.programs else None
+        self._silence_elapsed = 0.0
+
+    def select(self, name: str | None) -> None:
+        normalized = None if not name or str(name).upper() in ("NONE", "OFF") else str(name).upper()
+        if normalized is not None and normalized not in self.programs:
+            raise ValueError(f"unknown audio program: {name}")
+        if normalized == self.active_name:
+            return
+        self._transition_from = self.output.copy()
+        self._transition_elapsed = 0.0
+        self.active_name = normalized
+        self._silence_elapsed = 0.0
+        if normalized is not None:
+            self.programs[normalized].reset()
+        else:
+            self.output = RenderStateBatch.identity(self.topology.count)
+            self._transition_from = self.output.copy()
+            self._transition_elapsed = self.transition_seconds
+
+    def update(self, dt: float, now: float, frame: AudioFeatureFrame | None = None) -> RenderStateBatch:
+        if not self.active_name:
+            self.output = RenderStateBatch.identity(self.topology.count)
+            return self.output
+        frame = frame or AudioFeatureFrame.silence()
+        if (
+            not frame.system.active
+            and not frame.microphone.active
+            and max(frame.system.rms, frame.microphone.rms) < 0.01
+        ):
+            self._silence_elapsed += max(0.0, dt)
+        else:
+            self._silence_elapsed = 0.0
+        if self._silence_elapsed >= 1.5 - 1e-9:
+            self.programs[self.active_name].reset()
+            self.output = RenderStateBatch.identity(self.topology.count)
+            self._transition_from = self.output.copy()
+            self._transition_elapsed = self.transition_seconds
+            return self.output
+        target = self.programs[self.active_name].update(
+            min(max(0.0, float(dt)), 0.1),
+            float(now),
+            frame,
+            gain=self.sensitivity,
+            reactivity=self.reactivity,
+        )
+        if self._transition_elapsed < self.transition_seconds:
+            self._transition_elapsed += max(0.0, dt)
+            amount = min(1.0, self._transition_elapsed / self.transition_seconds)
+            # Cubic smoothstep avoids a visible velocity discontinuity.
+            amount = amount * amount * (3.0 - 2.0 * amount)
+            self.output = RenderStateBatch.blend(self._transition_from, target, amount)
+        else:
+            self.output = target
+        self.output.clamp(self.topology.core_radius, self.reduced_motion)
+        return self.output

--- a/animations/director.py
+++ b/animations/director.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 from audio.features import AudioFeatureFrame
 
 from .base import RenderStateBatch
@@ -10,6 +12,7 @@ from .cinematic_weather import CinematicWeather
 from .conversation_orbit import ConversationOrbit
 from .game_radar import GameRadar
 from .harmonic_aurora import HarmonicAurora
+from .resonance import OrganicResonatorBank
 from .signal_relay import SignalRelay
 from .spectrum_crown import SpectrumCrown
 from .topology import FormationTopology
@@ -31,6 +34,7 @@ class AnimationDirector:
     def __init__(self, pyramids=()):
         self.topology = FormationTopology(pyramids)
         self.programs = {name: program_type(self.topology) for name, program_type in PROGRAM_TYPES.items()}
+        self.resonators = OrganicResonatorBank(self.topology)
         self.active_name: str | None = None
         self.output = RenderStateBatch.identity(self.topology.count)
         self._transition_from = self.output.copy()
@@ -49,6 +53,7 @@ class AnimationDirector:
         selected = self.active_name
         self.topology = FormationTopology(pyramids)
         self.programs = {name: program_type(self.topology) for name, program_type in PROGRAM_TYPES.items()}
+        self.resonators = OrganicResonatorBank(self.topology)
         self.output = RenderStateBatch.identity(self.topology.count)
         self._transition_from = self.output.copy()
         self._transition_elapsed = self.transition_seconds
@@ -68,6 +73,7 @@ class AnimationDirector:
         if normalized is not None:
             self.programs[normalized].reset()
         else:
+            self.resonators.reset()
             self.output = RenderStateBatch.identity(self.topology.count)
             self._transition_from = self.output.copy()
             self._transition_elapsed = self.transition_seconds
@@ -87,17 +93,45 @@ class AnimationDirector:
             self._silence_elapsed = 0.0
         if self._silence_elapsed >= 1.5 - 1e-9:
             self.programs[self.active_name].reset()
+            self.resonators.reset()
             self.output = RenderStateBatch.identity(self.topology.count)
             self._transition_from = self.output.copy()
             self._transition_elapsed = self.transition_seconds
             return self.output
-        target = self.programs[self.active_name].update(
+        program_target = self.programs[self.active_name].update(
             min(max(0.0, float(dt)), 0.1),
             float(now),
             frame,
             gain=self.sensitivity,
             reactivity=self.reactivity,
         )
+        resonance = self.resonators.update(
+            min(max(0.0, float(dt)), 0.1),
+            float(now),
+            frame,
+            gain=self.sensitivity,
+        )
+        target = program_target.copy()
+        target.apex_scale += resonance.apex_scale - 1.0
+        target.radial_offset += resonance.radial_offset
+        target.line_alpha[:] = np.maximum(target.line_alpha, resonance.line_alpha)
+        target.line_width += resonance.line_width - 1.5
+        target.accent_mix[:] = np.clip(
+            target.accent_mix + resonance.accent_mix,
+            0.0,
+            0.88,
+        )
+        # Let the unique resonator hue lead only where its acoustic displacement
+        # is stronger than the program's macro response.
+        resonance_strength = np.clip(np.abs(self.resonators.displacement), 0.0, 1.0)
+        target.accent_hue[:] = np.mod(
+            target.accent_hue * (1.0 - resonance_strength)
+            + resonance.accent_hue * resonance_strength,
+            1.0,
+        )
+        if resonance.route_energy > target.route_energy:
+            target.route = resonance.route
+            target.route_energy = resonance.route_energy
         if self._transition_elapsed < self.transition_seconds:
             self._transition_elapsed += max(0.0, dt)
             amount = min(1.0, self._transition_elapsed / self.transition_seconds)

--- a/animations/game_radar.py
+++ b/animations/game_radar.py
@@ -1,0 +1,56 @@
+"""Game Radar: honest stereo-biased transient localization."""
+
+import math
+
+import numpy as np
+
+from .base import AudioAnimation, combine_features
+
+
+class GameRadar(AudioAnimation):
+    name = "RADAR"
+
+    def __init__(self, topology):
+        super().__init__(topology)
+        self.event_age = 99.0
+        self.seed = 0
+        self.low_strength = 0.0
+        self.high_strength = 0.0
+        self.event_balance = 0.0
+
+    def reset(self):
+        super().reset()
+        self.event_age = 99.0
+        self.low_strength = self.high_strength = 0.0
+
+    def update(self, dt, now, frame, gain=1.0, reactivity=1.0):
+        del now
+        feature = combine_features(frame)
+        self.event_age += dt
+        if self.is_new_frame(frame) and feature.onset:
+            self.event_balance = feature.stereo_balance
+            target = np.array([self.event_balance, 0.0, math.sqrt(max(0.0, 1.0 - self.event_balance ** 2))])
+            if abs(self.event_balance) < 0.08:
+                target = np.array([0.0, 0.0, 1.0])
+            self.seed = int(np.argmax(self.topology.normals @ target)) if self.topology.count else 0
+            self.low_strength = float(np.clip(np.mean(feature.bands[:3]) * feature.low_flux * gain * 2.2, 0.0, 1.0))
+            self.high_strength = float(np.clip(np.mean(feature.bands[5:]) * feature.high_flux * gain * 2.4, 0.0, 1.0))
+            self.event_age = 0.0
+        distance = self.topology.distances_from(self.seed).astype(float) if self.topology.count else np.zeros(0)
+        progress = self.event_age * 18.0 * reactivity
+        front = np.exp(-0.5 * np.square((distance - progress) / (0.7 + feature.stereo_width)))
+        decay = math.exp(-self.event_age / 0.72)
+        broad = front * self.low_strength * decay
+        needle = np.exp(-0.5 * np.square(distance / (0.8 + 2.2 * feature.stereo_width))) * self.high_strength * math.exp(-self.event_age / 0.18)
+        tremor = feature.rms * 0.035 * (0.5 + 0.5 * np.sin(np.arange(self.topology.count) * 2.4 + frame.monotonic_time * 11.0))
+        self.state.apex_scale[:] = 1.0 + 0.75 * needle + 0.22 * broad + tremor
+        self.state.radial_offset[:] = self.topology.core_radius * (0.13 * broad + 0.025 * tremor)
+        self.state.uniform_scale[:] = 1.0
+        self.state.line_alpha[:] = 0.61 + 0.36 * np.maximum(broad, needle)
+        self.state.line_width[:] = 1.35 + 2.1 * np.maximum(broad, needle)
+        self.state.accent_mix[:] = np.clip(0.75 * front * decay, 0.0, 0.84)
+        self.state.accent_hue[:] = np.mod((self.topology.azimuth + math.pi) / (2.0 * math.pi), 1.0)
+        self.state.particle_rate[:] = needle * 9.0
+        self.state.route = tuple(np.argsort(distance).tolist()) if len(distance) else ()
+        self.state.route_energy = float(np.clip(max(self.low_strength, self.high_strength) * decay, 0.0, 1.0))
+        return self.state

--- a/animations/harmonic_aurora.py
+++ b/animations/harmonic_aurora.py
@@ -1,0 +1,51 @@
+"""Harmonic Aurora: pitch-class constellations with noise-aware coherence."""
+
+import math
+
+import numpy as np
+
+from .base import AudioAnimation, combine_features, smooth
+
+
+class HarmonicAurora(AudioAnimation):
+    name = "AURORA"
+
+    def __init__(self, topology):
+        super().__init__(topology)
+        self.energy = np.zeros(topology.count, dtype=float)
+        self.previous_class = 0
+        self.route = ()
+
+    def reset(self):
+        super().reset()
+        self.energy[:] = 0.0
+        self.previous_class = 0
+        self.route = ()
+
+    def update(self, dt, now, frame, gain=1.0, reactivity=1.0):
+        del now
+        feature = combine_features(frame)
+        coherence = np.clip(feature.pitch_confidence * (1.0 - feature.flatness), 0.0, 1.0)
+        localized = self.topology.pitch_influence @ feature.pitch_classes
+        diffuse = np.full(self.topology.count, feature.rms * 0.22)
+        vertical = np.exp(-0.5 * np.square((self.topology.latitude - (feature.octave_position * 2.0 - 1.0)) / 0.5)) if self.topology.count else np.zeros(0)
+        target = np.clip((coherence * localized * (0.45 + 0.85 * vertical) + (1.0 - coherence) * diffuse) * gain * 2.8, 0.0, 1.0)
+        smooth(self.energy, target, dt, attack=0.06 / reactivity, release=0.42 / reactivity)
+        dominant_class = int(np.argmax(feature.pitch_classes)) if len(feature.pitch_classes) else 0
+        if self.is_new_frame(frame) and dominant_class != self.previous_class and coherence > 0.12 and self.topology.count:
+            old_node = int(np.argmax(self.topology.pitch_influence[:, self.previous_class]))
+            new_node = int(np.argmax(self.topology.pitch_influence[:, dominant_class]))
+            self.route = self.topology.shortest_path(old_node, new_node)
+            self.previous_class = dominant_class
+        shimmer = 0.025 * feature.rms * np.sin(np.arange(self.topology.count) * 1.7 + frame.monotonic_time * 2.2)
+        self.state.apex_scale[:] = 1.0 + 0.56 * self.energy + shimmer
+        self.state.radial_offset[:] = self.topology.core_radius * 0.09 * self.energy
+        self.state.uniform_scale[:] = 1.0
+        self.state.line_alpha[:] = 0.61 + 0.37 * self.energy
+        self.state.line_width[:] = 1.35 + 1.7 * self.energy
+        self.state.accent_mix[:] = np.clip(0.72 * self.energy, 0.0, 0.82)
+        self.state.accent_hue[:] = np.mod((self.topology.azimuth + math.pi) / (2.0 * math.pi), 1.0)
+        self.state.particle_rate[:] = self.energy * (4.0 if feature.onset and coherence > 0.22 else 0.0)
+        self.state.route = self.route
+        self.state.route_energy = float(np.clip(coherence * feature.rms * 1.5, 0.0, 1.0))
+        return self.state

--- a/animations/render.py
+++ b/animations/render.py
@@ -1,0 +1,48 @@
+"""Pure transient geometry transform used by the OpenGL renderer and tests."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+
+def _rotation_matrix_xyz(degrees):
+    pitch, yaw, roll = np.radians(degrees)
+    cx, sx = math.cos(pitch), math.sin(pitch)
+    cy, sy = math.cos(yaw), math.sin(yaw)
+    cz, sz = math.cos(roll), math.sin(roll)
+    rx = np.array([[1, 0, 0], [0, cx, -sx], [0, sx, cx]], dtype=float)
+    ry = np.array([[cy, 0, sy], [0, 1, 0], [-sy, 0, cy]], dtype=float)
+    rz = np.array([[cz, -sz, 0], [sz, cz, 0], [0, 0, 1]], dtype=float)
+    return rz @ ry @ rx
+
+
+def apply_render_state(path, topology, index, state):
+    """Return a modulated copy while leaving every authored point untouched.
+
+    Shared bases receive only one formation-wide scale, so the full Star cannot
+    crack apart.  Tip scale, radial travel, and rotation affect repeated apex
+    vertices only; base vertices remain exactly edge-sharing.
+    """
+    points = np.asarray(path, dtype=float).copy()
+    if not len(points):
+        return points
+    center = topology.centers[index]
+    apex = topology.apexes[index]
+    normal = topology.normals[index]
+    if topology.shared_surface:
+        global_scale = float(np.mean(state.uniform_scale))
+        points = topology.origin + (points - topology.origin) * global_scale
+        center = topology.origin + (center - topology.origin) * global_scale
+        apex = topology.origin + (apex - topology.origin) * global_scale
+    else:
+        points = center + (points - center) * float(state.uniform_scale[index])
+        apex = center + (apex - center) * float(state.uniform_scale[index])
+    apex_mask = np.linalg.norm(points - apex, axis=1) < 1e-5
+    tip_vector = apex - center
+    if np.any(state.rotation_offset[index]):
+        tip_vector = _rotation_matrix_xyz(state.rotation_offset[index]) @ tip_vector
+    new_apex = center + tip_vector * float(state.apex_scale[index]) + normal * float(state.radial_offset[index])
+    points[apex_mask] = new_apex
+    return points

--- a/animations/resonance.py
+++ b/animations/resonance.py
@@ -1,0 +1,106 @@
+"""Per-pyramid acoustic identities and organic spring micro-dynamics."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from .base import RenderStateBatch, combine_features
+
+
+class OrganicResonatorBank:
+    """Turn the fine spectrum into one coupled physical voice per pyramid.
+
+    Each node has a unique center frequency, bandwidth, harmonic mixture,
+    natural response rate, damping ratio, and modulation phase.  The simulation
+    uses a fixed step so its motion does not change with render frame rate.
+    """
+
+    def __init__(self, topology):
+        self.topology = topology
+        self.displacement = np.zeros(topology.count, dtype=float)
+        self.velocity = np.zeros(topology.count, dtype=float)
+        self.drive = np.zeros(topology.count, dtype=float)
+        self.state = RenderStateBatch.identity(topology.count)
+        variation = topology.resonance_variation
+        natural_hz = 0.72 + 1.65 * variation
+        self.stiffness = np.square(2.0 * math.pi * natural_hz)
+        damping_ratio = 0.52 + 0.34 * np.mod(variation * 1.61803398875, 1.0)
+        self.damping = 2.0 * damping_ratio * np.sqrt(self.stiffness)
+        self.phase = np.mod(variation * 17.0 + np.arange(topology.count) * 0.73, 2.0 * math.pi)
+        self.motion_hz = 0.45 + 1.35 * np.mod(variation * 2.41421356237, 1.0)
+        self.fixed_dt = 1.0 / 120.0
+        self.accumulator = 0.0
+        self.last_sequence = -1
+        self.coupling = 4.2
+
+    def reset(self):
+        self.displacement[:] = 0.0
+        self.velocity[:] = 0.0
+        self.drive[:] = 0.0
+        self.state = RenderStateBatch.identity(self.topology.count)
+        self.accumulator = 0.0
+        self.last_sequence = -1
+
+    def update(self, dt, now, frame, gain=1.0):
+        feature = combine_features(frame)
+        spectrum = np.asarray(feature.spectrum, dtype=float)
+        if self.topology.count and len(spectrum):
+            acoustic = self.topology.resonance_weights @ spectrum
+            personality = 0.78 + 0.44 * self.topology.resonance_variation
+            flutter = 1.0 + 0.055 * np.sin(
+                self.phase + now * 2.0 * math.pi * self.motion_hz
+            )
+            target = np.clip(acoustic * personality * flutter * gain * 3.2, 0.0, 1.0)
+            self.drive[:] = np.power(target, 1.12)
+        else:
+            self.drive[:] = 0.0
+
+        if frame.sequence != self.last_sequence:
+            self.last_sequence = frame.sequence
+            if feature.onset:
+                self.velocity += self.drive * (0.4 + 1.2 * feature.flux)
+
+        self.accumulator += min(max(0.0, float(dt)), 0.1)
+        steps = 0
+        while self.accumulator + 1e-12 >= self.fixed_dt and steps < 12:
+            acceleration = (
+                self.stiffness * (self.drive - self.displacement)
+                - self.damping * self.velocity
+            )
+            if len(self.topology.edges):
+                first = self.topology.edges[:, 0]
+                second = self.topology.edges[:, 1]
+                difference = self.displacement[second] - self.displacement[first]
+                np.add.at(acceleration, first, self.coupling * difference)
+                np.add.at(acceleration, second, -self.coupling * difference)
+            self.velocity += acceleration * self.fixed_dt
+            self.displacement += self.velocity * self.fixed_dt
+            self.displacement[:] = np.clip(self.displacement, -0.32, 1.18)
+            self.velocity[:] = np.clip(self.velocity, -9.0, 9.0)
+            self.accumulator -= self.fixed_dt
+            steps += 1
+        if steps == 12:
+            self.accumulator = min(self.accumulator, self.fixed_dt)
+
+        positive = np.clip(self.displacement, 0.0, 1.0)
+        magnitude = np.clip(np.abs(self.displacement), 0.0, 1.0)
+        self.state.apex_scale[:] = 1.0 + 0.24 * self.displacement
+        self.state.radial_offset[:] = self.topology.core_radius * 0.035 * self.displacement
+        self.state.uniform_scale[:] = 1.0
+        self.state.rotation_offset[:] = 0.0
+        self.state.line_alpha[:] = 0.68 + 0.16 * magnitude
+        self.state.line_width[:] = 1.5 + 0.58 * magnitude
+        # Keep the authored wireframe recognizably white; frequency color is a
+        # subtle active tint while the traveling route carries full rainbow.
+        self.state.accent_mix[:] = 0.12 * positive
+        log_frequency = np.log2(
+            self.topology.resonant_frequencies / max(1e-9, self.topology.resonant_frequencies.min(initial=35.0))
+        )
+        hue_span = max(float(log_frequency.max(initial=1.0)), 1e-9)
+        self.state.accent_hue[:] = log_frequency / hue_span
+        self.state.particle_rate[:] = 0.0
+        self.state.route = self.topology.greedy_route(magnitude, limit=64)
+        self.state.route_energy = float(np.clip(magnitude.max(initial=0.0), 0.0, 1.0))
+        return self.state

--- a/animations/signal_relay.py
+++ b/animations/signal_relay.py
@@ -1,0 +1,68 @@
+"""Signal Relay: fixed-step damped waves over the exact pyramid graph."""
+
+import numpy as np
+
+from .base import AudioAnimation, combine_features
+
+
+class SignalRelay(AudioAnimation):
+    name = "RELAY"
+
+    def __init__(self, topology):
+        super().__init__(topology)
+        self.displacement = np.zeros(topology.count, dtype=float)
+        self.velocity = np.zeros(topology.count, dtype=float)
+        self.accumulator = 0.0
+        self.fixed_dt = 1.0 / 120.0
+        self.coupling = 34.0
+        self.damping = 8.0
+
+    def reset(self):
+        super().reset()
+        self.displacement[:] = 0.0
+        self.velocity[:] = 0.0
+        self.accumulator = 0.0
+
+    def update(self, dt, now, frame, gain=1.0, reactivity=1.0):
+        del now
+        feature = combine_features(frame)
+        injection = np.zeros(self.topology.count, dtype=float)
+        if self.topology.count:
+            for band, seed in enumerate(self.topology.band_seeds):
+                injection[seed] += float(feature.bands[band]) * gain * (8.0 + 8.0 * feature.flux)
+        if self.is_new_frame(frame) and feature.onset and self.topology.count:
+            strongest = int(np.argmax(feature.bands))
+            self.velocity[self.topology.band_seeds[strongest]] += 1.1 + 2.0 * feature.flux
+        self.accumulator += min(float(dt), 0.1)
+        steps = 0
+        while self.accumulator + 1e-12 >= self.fixed_dt and steps < 12:
+            acceleration = -self.damping * self.velocity + injection
+            if len(self.topology.edges):
+                first = self.topology.edges[:, 0]
+                second = self.topology.edges[:, 1]
+                difference = self.displacement[second] - self.displacement[first]
+                np.add.at(acceleration, first, self.coupling * difference)
+                np.add.at(acceleration, second, -self.coupling * difference)
+            self.velocity += acceleration * self.fixed_dt
+            self.displacement += self.velocity * self.fixed_dt
+            self.displacement[:] = np.clip(self.displacement, -1.2, 1.2)
+            self.velocity[:] = np.clip(self.velocity, -8.0, 8.0)
+            self.accumulator -= self.fixed_dt
+            steps += 1
+        if steps == 12:
+            self.accumulator = min(self.accumulator, self.fixed_dt)
+        absolute = np.abs(self.displacement)
+        normalized = np.clip(absolute / 0.65, 0.0, 1.0)
+        self.state.apex_scale[:] = 1.0 + np.clip(self.displacement * 0.62, -0.42, 0.82)
+        self.state.radial_offset[:] = self.topology.core_radius * np.clip(self.displacement * 0.12, -0.22, 0.22)
+        self.state.uniform_scale[:] = 1.0
+        self.state.line_alpha[:] = 0.6 + 0.4 * normalized
+        self.state.line_width[:] = 1.35 + 2.0 * normalized
+        self.state.accent_mix[:] = 0.78 * normalized
+        self.state.accent_hue[:] = np.mod(0.58 + self.displacement * 0.35, 1.0)
+        collision = np.maximum(0.0, normalized - 0.82)
+        self.state.particle_rate[:] = collision * (2.0 + 6.0 * feature.flux)
+        start = int(np.argmax(absolute)) if self.topology.count else 0
+        self.state.route = self.topology.greedy_route(self.displacement, start=start, limit=64)
+        self.state.route_energy = float(normalized.max(initial=0.0))
+        return self.state

--- a/animations/signal_relay.py
+++ b/animations/signal_relay.py
@@ -28,8 +28,10 @@ class SignalRelay(AudioAnimation):
         feature = combine_features(frame)
         injection = np.zeros(self.topology.count, dtype=float)
         if self.topology.count:
+            spectral_drive = self.topology.resonance_weights @ np.asarray(feature.spectrum)
+            injection += np.power(np.clip(spectral_drive * 3.0, 0.0, 1.0), 1.5) * gain * 5.0
             for band, seed in enumerate(self.topology.band_seeds):
-                injection[seed] += float(feature.bands[band]) * gain * (8.0 + 8.0 * feature.flux)
+                injection[seed] += float(feature.bands[band]) * gain * (5.0 + 6.0 * feature.flux)
         if self.is_new_frame(frame) and feature.onset and self.topology.count:
             strongest = int(np.argmax(feature.bands))
             self.velocity[self.topology.band_seeds[strongest]] += 1.1 + 2.0 * feature.flux

--- a/animations/spectrum_crown.py
+++ b/animations/spectrum_crown.py
@@ -21,9 +21,10 @@ class SpectrumCrown(AudioAnimation):
     def update(self, dt, now, frame, gain=1.0, reactivity=1.0):
         del now
         feature = combine_features(frame)
-        target = self.topology.band_influence @ np.clip(feature.bands * gain, 0.0, 1.0)
-        target /= np.maximum(self.topology.band_influence.sum(axis=1), 0.45)
-        target = np.clip(target * 2.2, 0.0, 1.0)
+        macro = self.topology.band_influence @ np.clip(feature.bands * gain, 0.0, 1.0)
+        macro /= np.maximum(self.topology.band_influence.sum(axis=1), 0.45)
+        micro = self.topology.resonance_weights @ np.asarray(feature.spectrum)
+        target = np.clip(macro * 0.55 + micro * gain * 2.7, 0.0, 1.0)
         smooth(self.energy, target, dt, attack=0.025 / reactivity, release=0.34 / reactivity)
         self.state.apex_scale[:] = 1.0 + 0.72 * np.power(self.energy, 1.35)
         self.state.radial_offset[:] = 0.16 * self.topology.core_radius * self.energy
@@ -31,12 +32,11 @@ class SpectrumCrown(AudioAnimation):
         self.state.line_alpha[:] = 0.62 + 0.38 * self.energy
         self.state.line_width[:] = 1.35 + 1.65 * self.energy
         self.state.accent_mix[:] = 0.72 * self.energy
-        primary_band = np.argmax(self.topology.band_influence, axis=1)
-        self.state.accent_hue[:] = np.mod(feature.centroid * 0.45 + primary_band / 8.0, 1.0)
+        frequency_fraction = np.log2(self.topology.resonant_frequencies / 35.0) / np.log2(16000.0 / 35.0)
+        self.state.accent_hue[:] = np.mod(feature.centroid * 0.25 + frequency_fraction, 1.0)
         self.spark *= np.exp(-dt / 0.16)
         if self.is_new_frame(frame) and feature.onset:
-            strongest_band = int(np.argmax(feature.bands))
-            cluster = self.topology.band_influence[:, strongest_band]
+            cluster = np.clip(micro * 4.0, 0.0, 1.0)
             self.spark += cluster * (2.0 + 10.0 * feature.flux)
         self.state.particle_rate[:] = self.spark
         self.state.route = self.topology.greedy_route(self.energy)

--- a/animations/spectrum_crown.py
+++ b/animations/spectrum_crown.py
@@ -1,0 +1,44 @@
+"""Spectrum Crown: distribute eight frequency bands over precise face clusters."""
+
+import numpy as np
+
+from .base import AudioAnimation, combine_features, smooth
+
+
+class SpectrumCrown(AudioAnimation):
+    name = "CROWN"
+
+    def __init__(self, topology):
+        super().__init__(topology)
+        self.energy = np.zeros(topology.count, dtype=float)
+        self.spark = np.zeros(topology.count, dtype=float)
+
+    def reset(self):
+        super().reset()
+        self.energy[:] = 0.0
+        self.spark[:] = 0.0
+
+    def update(self, dt, now, frame, gain=1.0, reactivity=1.0):
+        del now
+        feature = combine_features(frame)
+        target = self.topology.band_influence @ np.clip(feature.bands * gain, 0.0, 1.0)
+        target /= np.maximum(self.topology.band_influence.sum(axis=1), 0.45)
+        target = np.clip(target * 2.2, 0.0, 1.0)
+        smooth(self.energy, target, dt, attack=0.025 / reactivity, release=0.34 / reactivity)
+        self.state.apex_scale[:] = 1.0 + 0.72 * np.power(self.energy, 1.35)
+        self.state.radial_offset[:] = 0.16 * self.topology.core_radius * self.energy
+        self.state.uniform_scale[:] = 1.0
+        self.state.line_alpha[:] = 0.62 + 0.38 * self.energy
+        self.state.line_width[:] = 1.35 + 1.65 * self.energy
+        self.state.accent_mix[:] = 0.72 * self.energy
+        primary_band = np.argmax(self.topology.band_influence, axis=1)
+        self.state.accent_hue[:] = np.mod(feature.centroid * 0.45 + primary_band / 8.0, 1.0)
+        self.spark *= np.exp(-dt / 0.16)
+        if self.is_new_frame(frame) and feature.onset:
+            strongest_band = int(np.argmax(feature.bands))
+            cluster = self.topology.band_influence[:, strongest_band]
+            self.spark += cluster * (2.0 + 10.0 * feature.flux)
+        self.state.particle_rate[:] = self.spark
+        self.state.route = self.topology.greedy_route(self.energy)
+        self.state.route_energy = float(max(feature.rms, feature.flux * 0.8))
+        return self.state

--- a/animations/topology.py
+++ b/animations/topology.py
@@ -1,0 +1,176 @@
+"""Immutable formation geometry, adjacency, and influence caches."""
+
+from __future__ import annotations
+
+from collections import deque
+import math
+
+import numpy as np
+
+
+def _normalize_rows(values: np.ndarray) -> np.ndarray:
+    lengths = np.linalg.norm(values, axis=1, keepdims=True)
+    lengths[lengths < 1e-9] = 1.0
+    return values / lengths
+
+
+class FormationTopology:
+    def __init__(self, pyramids):
+        self.count = len(pyramids)
+        self.home_paths = []
+        bases = []
+        apexes = []
+        for pyramid in pyramids:
+            local = pyramid._apply_corner_offsets_to_local_path(pyramid.local_path)
+            path = np.asarray(
+                pyramid.transform_path(local, pyramid.physics.position, pyramid.physics.rotation),
+                dtype=float,
+            )
+            self.home_paths.append(path)
+            bases.append(path[: pyramid.num_corners].mean(axis=0))
+            apex_index = min(len(path) - 1, pyramid.num_corners + 1)
+            apexes.append(path[apex_index])
+        self.centers = np.asarray(bases, dtype=float) if bases else np.empty((0, 3), dtype=float)
+        self.apexes = np.asarray(apexes, dtype=float) if apexes else np.empty((0, 3), dtype=float)
+        self.origin = self.centers.mean(axis=0) if self.count else np.zeros(3)
+        raw_normals = self.apexes - self.centers
+        self.normals = _normalize_rows(raw_normals) if self.count else np.empty((0, 3))
+        radii = np.linalg.norm(self.centers - self.origin, axis=1) if self.count else np.zeros(0)
+        self.core_radius = max(0.5, float(np.median(radii))) if len(radii) else 1.0
+        self.latitude = self.normals[:, 1] if self.count else np.zeros(0)
+        self.azimuth = np.arctan2(self.normals[:, 2], self.normals[:, 0]) if self.count else np.zeros(0)
+        self.adjacency, shared_edges = self._build_adjacency(pyramids)
+        self.shared_surface = shared_edges >= max(1, self.count // 2)
+        self.edges = np.asarray(
+            [(i, j) for i, neighbors in enumerate(self.adjacency) for j in neighbors if i < j],
+            dtype=np.int32,
+        ).reshape(-1, 2)
+        self.parity = self._build_parity()
+        self.band_influence = self._build_band_influence()
+        self.pitch_influence = self._build_pitch_influence()
+        self.band_seeds = tuple(int(np.argmax(self.band_influence[:, band])) for band in range(8)) if self.count else ()
+        self._distance_cache: dict[int, np.ndarray] = {}
+
+    def _build_adjacency(self, pyramids):
+        adjacency = [set() for _ in range(self.count)]
+        edge_owners: dict[tuple, int] = {}
+        shared = 0
+        for index, (pyramid, path) in enumerate(zip(pyramids, self.home_paths)):
+            base = path[: pyramid.num_corners]
+            for edge_index in range(pyramid.num_corners):
+                first = tuple(np.round(base[edge_index], 6))
+                second = tuple(np.round(base[(edge_index + 1) % pyramid.num_corners], 6))
+                edge = tuple(sorted((first, second)))
+                other = edge_owners.get(edge)
+                if other is None:
+                    edge_owners[edge] = index
+                else:
+                    adjacency[index].add(other)
+                    adjacency[other].add(index)
+                    shared += 1
+
+        # Spaced formations have no shared base edges.  A symmetric nearest-
+        # neighbor graph gives every mode a stable route without changing shape.
+        if self.count > 1 and not any(adjacency):
+            neighbor_count = min(4, self.count - 1)
+            for index in range(self.count):
+                distance = np.linalg.norm(self.centers - self.centers[index], axis=1)
+                for other in np.argsort(distance)[1 : neighbor_count + 1]:
+                    adjacency[index].add(int(other))
+                    adjacency[int(other)].add(index)
+        return tuple(tuple(sorted(items)) for items in adjacency), shared
+
+    def _build_parity(self):
+        parity = np.zeros(self.count, dtype=int)
+        visited = np.zeros(self.count, dtype=bool)
+        for root in range(self.count):
+            if visited[root]:
+                continue
+            visited[root] = True
+            queue = deque([root])
+            while queue:
+                node = queue.popleft()
+                for neighbor in self.adjacency[node]:
+                    if not visited[neighbor]:
+                        visited[neighbor] = True
+                        parity[neighbor] = 1 - parity[node]
+                        queue.append(neighbor)
+        return parity
+
+    def _build_band_influence(self):
+        if not self.count:
+            return np.empty((0, 8), dtype=float)
+        targets = np.array([
+            [0.0, 1.0, 0.0], [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0], [-0.5, 0.0, 0.866], [-0.5, 0.0, -0.866],
+            [0.68, 0.55, 0.48], [-0.78, 0.48, 0.40], [0.05, -0.55, -0.83],
+        ], dtype=float)
+        targets = _normalize_rows(targets)
+        widths = np.array([1.9, 1.9, 2.5, 2.5, 2.5, 4.2, 4.8, 5.4])
+        dots = np.clip(self.normals @ targets.T, -1.0, 1.0)
+        influence = np.exp((dots - 1.0) * widths[None, :])
+        # The secondary-band contribution prevents hard seams.
+        influence = 0.75 * influence + 0.125 * np.roll(influence, 1, axis=1) + 0.125 * np.roll(influence, -1, axis=1)
+        column_max = np.maximum(influence.max(axis=0, keepdims=True), 1e-9)
+        return influence / column_max
+
+    def _build_pitch_influence(self):
+        if not self.count:
+            return np.empty((0, 12), dtype=float)
+        target_angles = np.arange(12, dtype=float) / 12.0 * 2.0 * math.pi - math.pi
+        delta = np.angle(np.exp(1j * (self.azimuth[:, None] - target_angles[None, :])))
+        return np.exp(-0.5 * np.square(delta / 0.42))
+
+    def distances_from(self, seed: int) -> np.ndarray:
+        seed = int(np.clip(seed, 0, max(0, self.count - 1)))
+        if seed in self._distance_cache:
+            return self._distance_cache[seed]
+        distance = np.full(self.count, self.count + 1, dtype=np.int32)
+        if self.count:
+            distance[seed] = 0
+            queue = deque([seed])
+            while queue:
+                node = queue.popleft()
+                for neighbor in self.adjacency[node]:
+                    if distance[neighbor] > distance[node] + 1:
+                        distance[neighbor] = distance[node] + 1
+                        queue.append(neighbor)
+        self._distance_cache[seed] = distance
+        return distance
+
+    def shortest_path(self, start: int, goal: int) -> tuple[int, ...]:
+        if not self.count:
+            return ()
+        start, goal = int(start), int(goal)
+        previous = {start: None}
+        queue = deque([start])
+        while queue and goal not in previous:
+            node = queue.popleft()
+            for neighbor in self.adjacency[node]:
+                if neighbor not in previous:
+                    previous[neighbor] = node
+                    queue.append(neighbor)
+        if goal not in previous:
+            return (start,)
+        route = []
+        cursor = goal
+        while cursor is not None:
+            route.append(cursor)
+            cursor = previous[cursor]
+        return tuple(reversed(route))
+
+    def greedy_route(self, energy: np.ndarray, start: int | None = None, limit=48) -> tuple[int, ...]:
+        if not self.count:
+            return ()
+        values = np.asarray(energy, dtype=float)
+        node = int(np.argmax(values) if start is None else start)
+        route = [node]
+        visited = {node}
+        for _ in range(min(int(limit), self.count) - 1):
+            options = [item for item in self.adjacency[node] if item not in visited]
+            if not options:
+                break
+            node = max(options, key=lambda item: values[item])
+            route.append(node)
+            visited.add(node)
+        return tuple(route)

--- a/animations/topology.py
+++ b/animations/topology.py
@@ -7,6 +7,8 @@ import math
 
 import numpy as np
 
+from audio.features import SPECTRUM_FREQUENCIES, SPECTRUM_MAX_HZ, SPECTRUM_MIN_HZ
+
 
 def _normalize_rows(values: np.ndarray) -> np.ndarray:
     lengths = np.linalg.norm(values, axis=1, keepdims=True)
@@ -48,6 +50,12 @@ class FormationTopology:
         self.parity = self._build_parity()
         self.band_influence = self._build_band_influence()
         self.pitch_influence = self._build_pitch_influence()
+        (
+            self.resonant_frequencies,
+            self.resonance_bandwidths,
+            self.resonance_weights,
+            self.resonance_variation,
+        ) = self._build_resonance_map()
         self.band_seeds = tuple(int(np.argmax(self.band_influence[:, band])) for band in range(8)) if self.count else ()
         self._distance_cache: dict[int, np.ndarray] = {}
 
@@ -120,6 +128,52 @@ class FormationTopology:
         target_angles = np.arange(12, dtype=float) / 12.0 * 2.0 * math.pi - math.pi
         delta = np.angle(np.exp(1j * (self.azimuth[:, None] - target_angles[None, :])))
         return np.exp(-0.5 * np.square(delta / 0.42))
+
+    def _build_resonance_map(self):
+        """Assign every pyramid a distinct frequency and acoustic character.
+
+        Frequencies progress over a geometry-derived spiral instead of pyramid
+        creation order.  Neighboring resonators overlap, but no two pyramids
+        have the exact same center frequency when the formation has >1 member.
+        """
+        if not self.count:
+            return (
+                np.zeros(0),
+                np.zeros(0),
+                np.empty((0, len(SPECTRUM_FREQUENCIES))),
+                np.zeros(0),
+            )
+        index = np.arange(self.count, dtype=float)
+        azimuth = np.mod((self.azimuth + math.pi) / (2.0 * math.pi), 1.0)
+        latitude = (self.latitude + 1.0) * 0.5
+        spiral_key = np.mod(azimuth + latitude * 0.61803398875, 1.0)
+        order = np.lexsort((index, latitude, spiral_key))
+        rank = np.empty(self.count, dtype=float)
+        rank[order] = np.arange(self.count, dtype=float)
+        fraction = rank / max(1.0, self.count - 1.0)
+        frequencies = SPECTRUM_MIN_HZ * np.power(
+            SPECTRUM_MAX_HZ / SPECTRUM_MIN_HZ,
+            fraction,
+        )
+        variation = np.mod(
+            np.sin((index + 1.0) * 12.9898 + self.latitude * 4.1414) * 43758.5453,
+            1.0,
+        )
+        bandwidths = 0.26 + 0.46 * variation  # octave standard deviation
+        input_frequencies = SPECTRUM_FREQUENCIES[None, :]
+        center = frequencies[:, None]
+
+        def gaussian_at(multiplier, width_scale=1.0):
+            distance = np.log2(input_frequencies / np.maximum(center * multiplier, 1e-9))
+            return np.exp(-0.5 * np.square(distance / (bandwidths[:, None] * width_scale)))
+
+        fundamental = gaussian_at(1.0)
+        second_harmonic = gaussian_at(2.0, 1.18) * (0.08 + 0.28 * variation[:, None])
+        third_harmonic = gaussian_at(3.0, 1.28) * (0.04 + 0.18 * (1.0 - variation[:, None]))
+        subharmonic = gaussian_at(0.5, 1.22) * (0.03 + 0.12 * variation[:, None])
+        weights = fundamental + second_harmonic + third_harmonic + subharmonic
+        weights /= np.maximum(weights.sum(axis=1, keepdims=True), 1e-12)
+        return frequencies, bandwidths, weights, variation
 
     def distances_from(self, seed: int) -> np.ndarray:
         seed = int(np.clip(seed, 0, max(0, self.count - 1)))

--- a/audio/__init__.py
+++ b/audio/__init__.py
@@ -1,0 +1,12 @@
+"""Local, in-memory audio analysis for Rainbow Starburst."""
+
+from .engine import AudioEngine, AudioSourceMode
+from .features import AudioFeatureFrame, FeatureAnalyzer, SourceFeatures
+
+__all__ = [
+    "AudioEngine",
+    "AudioSourceMode",
+    "AudioFeatureFrame",
+    "FeatureAnalyzer",
+    "SourceFeatures",
+]

--- a/audio/capture.py
+++ b/audio/capture.py
@@ -1,0 +1,148 @@
+"""PortAudio capture lifecycle and analyzer worker."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import threading
+import time
+from typing import Callable
+
+import numpy as np
+
+from .devices import AudioDevice, pyaudio
+from .features import FeatureAnalyzer, SourceFeatures
+from .ring_buffer import AudioRingBuffer
+
+
+@dataclass(frozen=True)
+class CaptureStatus:
+    state: str = "stopped"
+    message: str = "STOPPED"
+    latency_ms: float = 0.0
+    dropped_windows: int = 0
+
+
+class AudioCapture:
+    """One selected endpoint, one callback ring, and one analyzer worker."""
+
+    def __init__(self, device: AudioDevice, publish: Callable[[SourceFeatures, CaptureStatus], None]):
+        self.device = device
+        self.publish = publish
+        self.ring: AudioRingBuffer | None = None
+        self.analyzer: FeatureAnalyzer | None = None
+        self._audio = None
+        self._stream = None
+        self._worker: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._status = CaptureStatus()
+        self._status_lock = threading.Lock()
+        self._last_callback = 0.0
+
+    @property
+    def status(self) -> CaptureStatus:
+        with self._status_lock:
+            return self._status
+
+    @property
+    def is_active(self) -> bool:
+        try:
+            return self._stream is not None and bool(self._stream.is_active()) and not self._stop.is_set()
+        except Exception:
+            return False
+
+    def start(self) -> None:
+        if pyaudio is None:
+            raise RuntimeError("PyAudio is not installed")
+        self.stop()
+        self._stop.clear()
+        self._audio = pyaudio.PyAudio()
+        rate = self.device.sample_rate
+        channels = self.device.channels
+        self.ring = AudioRingBuffer(max(rate * 2, 4096), channels)
+        self.analyzer = FeatureAnalyzer(rate, channels)
+
+        def callback(in_data, frame_count, time_info, status_flags):
+            del time_info, status_flags
+            if self._stop.is_set():
+                return (None, pyaudio.paComplete)
+            try:
+                samples = np.frombuffer(in_data, dtype=np.float32)
+                usable = (samples.size // channels) * channels
+                if usable:
+                    self.ring.write(samples[:usable].reshape(-1, channels))
+                    self._last_callback = time.monotonic()
+            except Exception as exc:
+                self._set_status("error", f"CALLBACK ERROR: {exc}")
+            return (None, pyaudio.paContinue)
+
+        try:
+            self._stream = self._audio.open(
+                format=pyaudio.paFloat32,
+                channels=channels,
+                rate=rate,
+                input=True,
+                input_device_index=self.device.index,
+                frames_per_buffer=512,
+                stream_callback=callback,
+                start=True,
+            )
+        except Exception:
+            self.stop()
+            raise
+
+        self._set_status("live", f"LIVE: {self.device.name}", 1024 / rate * 1000.0, 0)
+        self._worker = threading.Thread(
+            target=self._analysis_loop,
+            name=f"rainbowstarburst-{self.device.kind}-analysis",
+            daemon=True,
+        )
+        self._worker.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        stream, self._stream = self._stream, None
+        if stream is not None:
+            try:
+                stream.stop_stream()
+            except Exception:
+                pass
+            try:
+                stream.close()
+            except Exception:
+                pass
+        worker, self._worker = self._worker, None
+        if worker is not None and worker is not threading.current_thread():
+            worker.join(timeout=1.0)
+        audio, self._audio = self._audio, None
+        if audio is not None:
+            try:
+                audio.terminate()
+            except Exception:
+                pass
+        self._set_status("stopped", "STOPPED")
+
+    def _analysis_loop(self) -> None:
+        assert self.ring is not None and self.analyzer is not None
+        hop = self.analyzer.hop_size
+        period = hop / float(self.device.sample_rate)
+        while not self._stop.wait(min(0.01, period)):
+            processed = False
+            while self.ring.available >= hop:
+                chunk = self.ring.read(hop)
+                feature = self.analyzer.push(chunk, time.monotonic())
+                if feature is None:
+                    continue
+                processed = True
+                latency = (self.ring.available + self.analyzer.window_size) / self.device.sample_rate * 1000.0
+                dropped_windows = self.ring.dropped_frames // hop
+                status = CaptureStatus("live", f"LIVE: {self.device.name}", latency, dropped_windows)
+                self._set_status(status.state, status.message, latency, dropped_windows)
+                self.publish(feature, status)
+            if not processed and self._last_callback and time.monotonic() - self._last_callback > 2.5:
+                # Event-driven loopback endpoints can legitimately stop
+                # delivering callbacks while the output mix is silent.
+                self._set_status("silent", f"LIVE / SILENT: {self.device.name}")
+
+    def _set_status(self, state, message, latency_ms=0.0, dropped_windows=0) -> None:
+        with self._status_lock:
+            self._status = CaptureStatus(state, str(message), float(latency_ms), int(dropped_windows))

--- a/audio/devices.py
+++ b/audio/devices.py
@@ -1,0 +1,111 @@
+"""Audio endpoint discovery with optional WASAPI loopback support."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import platform
+
+
+try:  # PyAudioWPatch must win because it adds loopback endpoint helpers.
+    import pyaudiowpatch as pyaudio  # type: ignore
+
+    HAS_WASAPI_LOOPBACK = platform.system() == "Windows"
+    BACKEND_NAME = "PyAudioWPatch"
+except ImportError:  # Standard PyAudio still provides microphone support.
+    try:
+        import pyaudio  # type: ignore
+
+        HAS_WASAPI_LOOPBACK = False
+        BACKEND_NAME = "PyAudio"
+    except ImportError:
+        pyaudio = None
+        HAS_WASAPI_LOOPBACK = False
+        BACKEND_NAME = "unavailable"
+
+
+@dataclass(frozen=True)
+class AudioDevice:
+    identifier: str
+    index: int
+    name: str
+    kind: str
+    sample_rate: int
+    channels: int
+    is_default: bool = False
+
+
+class AudioDeviceManager:
+    """Enumerate microphone and loopback devices without holding them open."""
+
+    def enumerate(self) -> tuple[list[AudioDevice], list[AudioDevice]]:
+        if pyaudio is None:
+            return [], []
+        audio = pyaudio.PyAudio()
+        try:
+            default_input = self._default_index(audio, input_device=True)
+            microphones = []
+            loopbacks = []
+            for index in range(int(audio.get_device_count())):
+                try:
+                    info = audio.get_device_info_by_index(index)
+                except Exception:
+                    continue
+                channels = int(info.get("maxInputChannels", 0) or 0)
+                if channels <= 0:
+                    continue
+                name = str(info.get("name", f"Device {index}"))
+                rate = int(float(info.get("defaultSampleRate", 48000) or 48000))
+                is_loopback = bool(info.get("isLoopbackDevice", False))
+                kind = "system" if is_loopback else "microphone"
+                device = AudioDevice(
+                    identifier=f"{kind}:{index}",
+                    index=index,
+                    name=name,
+                    kind=kind,
+                    sample_rate=rate,
+                    channels=min(2, channels),
+                    is_default=(index == default_input and not is_loopback),
+                )
+                (loopbacks if is_loopback else microphones).append(device)
+
+            default_loopback_index = self._default_loopback_index(audio, loopbacks)
+            if default_loopback_index is not None:
+                loopbacks = [
+                    AudioDevice(**{**device.__dict__, "is_default": device.index == default_loopback_index})
+                    for device in loopbacks
+                ]
+            microphones.sort(key=lambda item: (not item.is_default, item.name.casefold()))
+            loopbacks.sort(key=lambda item: (not item.is_default, item.name.casefold()))
+            return loopbacks, microphones
+        finally:
+            audio.terminate()
+
+    def _default_index(self, audio, input_device: bool) -> int | None:
+        try:
+            info = audio.get_default_input_device_info() if input_device else audio.get_default_output_device_info()
+            return int(info["index"])
+        except Exception:
+            return None
+
+    def _default_loopback_index(self, audio, loopbacks: list[AudioDevice]) -> int | None:
+        if not loopbacks:
+            return None
+        try:
+            output = audio.get_default_output_device_info()
+            output_name = str(output.get("name", "")).casefold()
+        except Exception:
+            return loopbacks[0].index
+        for device in loopbacks:
+            loop_name = device.name.casefold()
+            if output_name and (output_name in loop_name or loop_name in output_name):
+                return device.index
+        return loopbacks[0].index
+
+    def resolve(self, kind: str, identifier: str | None = None) -> AudioDevice | None:
+        systems, microphones = self.enumerate()
+        candidates = systems if kind == "system" else microphones
+        if identifier:
+            for device in candidates:
+                if device.identifier == identifier:
+                    return device
+        return candidates[0] if candidates else None

--- a/audio/diagnostic.py
+++ b/audio/diagnostic.py
@@ -1,0 +1,70 @@
+"""Command-line endpoint and feature diagnostic; never records audio."""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+from .devices import AudioDeviceManager, BACKEND_NAME, HAS_WASAPI_LOOPBACK
+from .engine import AudioEngine, AudioSourceMode
+
+
+def list_devices() -> None:
+    systems, microphones = AudioDeviceManager().enumerate()
+    print(f"Backend: {BACKEND_NAME}; WASAPI loopback: {HAS_WASAPI_LOOPBACK}")
+    print("\nSystem output loopbacks:")
+    for device in systems:
+        marker = " [default]" if device.is_default else ""
+        print(f"  {device.identifier}: {device.name} ({device.sample_rate} Hz, {device.channels} ch){marker}")
+    if not systems:
+        print("  none")
+    print("\nMicrophones:")
+    for device in microphones:
+        marker = " [default]" if device.is_default else ""
+        print(f"  {device.identifier}: {device.name} ({device.sample_rate} Hz, {device.channels} ch){marker}")
+    if not microphones:
+        print("  none")
+
+
+def monitor(source: str, seconds: float) -> None:
+    mode = AudioSourceMode(source.upper())
+    engine = AudioEngine()
+    try:
+        engine.configure(mode)
+        print("Live analysis only. No audio is being recorded or transmitted.")
+        deadline = time.monotonic() + max(0.1, seconds)
+        while time.monotonic() < deadline:
+            frame = engine.snapshot()
+            status = engine.status()
+            print(
+                f"\rseq={frame.sequence:6d}  system={frame.system.rms:0.3f}  "
+                f"mic={frame.microphone.rms:0.3f}  latency={frame.capture_latency_ms:5.1f} ms  "
+                f"drops={frame.dropped_windows}  "
+                f"[{status['system'].state}/{status['microphone'].state}]",
+                end="",
+                flush=True,
+            )
+            time.sleep(0.1)
+        print()
+    finally:
+        engine.shutdown()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="list capture endpoints")
+    parser.add_argument(
+        "--source",
+        choices=("system", "mic", "both", "demo"),
+        help="monitor normalized levels from a source",
+    )
+    parser.add_argument("--seconds", type=float, default=10.0, help="monitor duration")
+    args = parser.parse_args()
+    if args.list or not args.source:
+        list_devices()
+    if args.source:
+        monitor(args.source, args.seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/audio/engine.py
+++ b/audio/engine.py
@@ -1,0 +1,223 @@
+"""Source orchestration, simulation, recovery, and immutable snapshots."""
+
+from __future__ import annotations
+
+from enum import Enum
+import math
+import threading
+import time
+
+import numpy as np
+
+from .capture import AudioCapture, CaptureStatus
+from .devices import AudioDeviceManager, BACKEND_NAME, HAS_WASAPI_LOOPBACK
+from .features import AudioFeatureFrame, FeatureAnalyzer, SourceFeatures
+
+
+class AudioSourceMode(str, Enum):
+    OFF = "OFF"
+    SYSTEM = "SYSTEM"
+    MICROPHONE = "MIC"
+    BOTH = "BOTH"
+    DEMO = "DEMO"
+
+
+class AudioEngine:
+    """Own capture sessions while exposing a lock-free-sized feature snapshot."""
+
+    def __init__(self):
+        self.device_manager = AudioDeviceManager()
+        self.mode = AudioSourceMode.OFF
+        self.system_device_id: str | None = None
+        self.microphone_device_id: str | None = None
+        self._system = SourceFeatures.silence()
+        self._microphone = SourceFeatures.silence()
+        self._system_status = CaptureStatus(message="SYSTEM OFF")
+        self._microphone_status = CaptureStatus(message="MIC OFF")
+        self._system_capture: AudioCapture | None = None
+        self._microphone_capture: AudioCapture | None = None
+        self._sequence = 0
+        self._lock = threading.RLock()
+        self._demo_stop = threading.Event()
+        self._demo_thread: threading.Thread | None = None
+        self._monitor_stop = threading.Event()
+        self._next_retry = 0.0
+        self._monitor = threading.Thread(target=self._monitor_loop, name="rainbowstarburst-audio-monitor", daemon=True)
+        self._monitor.start()
+
+    @property
+    def backend_name(self) -> str:
+        return BACKEND_NAME
+
+    @property
+    def supports_loopback(self) -> bool:
+        return HAS_WASAPI_LOOPBACK
+
+    def devices(self):
+        try:
+            return self.device_manager.enumerate()
+        except Exception:
+            return [], []
+
+    def configure(
+        self,
+        mode: AudioSourceMode | str,
+        system_device_id: str | None = None,
+        microphone_device_id: str | None = None,
+    ) -> None:
+        selected = mode if isinstance(mode, AudioSourceMode) else AudioSourceMode(str(mode).upper())
+        with self._lock:
+            self.mode = selected
+            if system_device_id is not None:
+                self.system_device_id = system_device_id
+            if microphone_device_id is not None:
+                self.microphone_device_id = microphone_device_id
+        self._stop_sessions()
+        if selected == AudioSourceMode.DEMO:
+            self._start_demo()
+        elif selected != AudioSourceMode.OFF:
+            self._ensure_sessions(force=True)
+
+    def snapshot(self) -> AudioFeatureFrame:
+        with self._lock:
+            system_status = self._system_capture.status if self._system_capture is not None else self._system_status
+            microphone_status = self._microphone_capture.status if self._microphone_capture is not None else self._microphone_status
+            system = self._system if self.mode in (AudioSourceMode.SYSTEM, AudioSourceMode.BOTH, AudioSourceMode.DEMO) else SourceFeatures.silence()
+            microphone = self._microphone if self.mode in (AudioSourceMode.MICROPHONE, AudioSourceMode.BOTH, AudioSourceMode.DEMO) else SourceFeatures.silence()
+            latency = max(system_status.latency_ms, microphone_status.latency_ms)
+            dropped = system_status.dropped_windows + microphone_status.dropped_windows
+            return AudioFeatureFrame(self._sequence, time.monotonic(), system, microphone, latency, dropped)
+
+    def status(self) -> dict[str, object]:
+        with self._lock:
+            system_status = self._system_capture.status if self._system_capture is not None else self._system_status
+            microphone_status = self._microphone_capture.status if self._microphone_capture is not None else self._microphone_status
+            return {
+                "mode": self.mode.value,
+                "backend": BACKEND_NAME,
+                "loopback_supported": HAS_WASAPI_LOOPBACK,
+                "system": system_status,
+                "microphone": microphone_status,
+            }
+
+    def shutdown(self) -> None:
+        with self._lock:
+            self.mode = AudioSourceMode.OFF
+        self._monitor_stop.set()
+        self._stop_sessions()
+        if self._monitor is not threading.current_thread():
+            self._monitor.join(timeout=1.0)
+
+    def _publish_system(self, feature: SourceFeatures, status: CaptureStatus) -> None:
+        with self._lock:
+            self._system = feature
+            self._system_status = status
+            self._sequence += 1
+
+    def _publish_microphone(self, feature: SourceFeatures, status: CaptureStatus) -> None:
+        with self._lock:
+            self._microphone = feature
+            self._microphone_status = status
+            self._sequence += 1
+
+    def _stop_sessions(self) -> None:
+        self._demo_stop.set()
+        demo, self._demo_thread = self._demo_thread, None
+        if demo is not None and demo is not threading.current_thread():
+            demo.join(timeout=1.0)
+        for capture_name in ("_system_capture", "_microphone_capture"):
+            capture = getattr(self, capture_name)
+            setattr(self, capture_name, None)
+            if capture is not None:
+                capture.stop()
+        with self._lock:
+            self._system = SourceFeatures.silence()
+            self._microphone = SourceFeatures.silence()
+            if self.mode == AudioSourceMode.OFF:
+                self._system_status = CaptureStatus(message="SYSTEM OFF")
+                self._microphone_status = CaptureStatus(message="MIC OFF")
+
+    def _ensure_sessions(self, force=False) -> None:
+        with self._lock:
+            mode = self.mode
+        if mode in (AudioSourceMode.OFF, AudioSourceMode.DEMO):
+            return
+        now = time.monotonic()
+        if not force and now < self._next_retry:
+            return
+        self._next_retry = now + 3.0
+        wants_system = mode in (AudioSourceMode.SYSTEM, AudioSourceMode.BOTH)
+        wants_mic = mode in (AudioSourceMode.MICROPHONE, AudioSourceMode.BOTH)
+        if wants_system and (self._system_capture is None or not self._system_capture.is_active):
+            if self._system_capture is not None:
+                self._system_capture.stop()
+            self._system_capture = self._open_capture("system", self.system_device_id, self._publish_system)
+        if wants_mic and (self._microphone_capture is None or not self._microphone_capture.is_active):
+            if self._microphone_capture is not None:
+                self._microphone_capture.stop()
+            self._microphone_capture = self._open_capture("microphone", self.microphone_device_id, self._publish_microphone)
+
+    def _open_capture(self, kind, identifier, publish) -> AudioCapture | None:
+        try:
+            device = self.device_manager.resolve(kind, identifier)
+            if device is None:
+                raise RuntimeError("no compatible endpoint found")
+            capture = AudioCapture(device, publish)
+            capture.start()
+            if kind == "system":
+                self.system_device_id = device.identifier
+                self._system_status = capture.status
+            else:
+                self.microphone_device_id = device.identifier
+                self._microphone_status = capture.status
+            return capture
+        except Exception as exc:
+            status = CaptureStatus("unavailable", f"{kind.upper()} UNAVAILABLE: {exc}")
+            with self._lock:
+                if kind == "system":
+                    self._system_status = status
+                    self._system = SourceFeatures.silence()
+                else:
+                    self._microphone_status = status
+                    self._microphone = SourceFeatures.silence()
+            return None
+
+    def _monitor_loop(self) -> None:
+        while not self._monitor_stop.wait(1.0):
+            self._ensure_sessions()
+
+    def _start_demo(self) -> None:
+        self._demo_stop.clear()
+        self._demo_thread = threading.Thread(target=self._demo_loop, name="rainbowstarburst-demo-audio", daemon=True)
+        self._demo_thread.start()
+
+    def _demo_loop(self) -> None:
+        rate, hop = 48000, 512
+        system_analyzer = FeatureAnalyzer(rate, 2)
+        mic_analyzer = FeatureAnalyzer(rate, 1)
+        cursor = 0
+        start = time.monotonic()
+        while not self._demo_stop.is_set():
+            t = (np.arange(hop, dtype=float) + cursor) / rate
+            elapsed = time.monotonic() - start
+            beat = (elapsed % 0.5) < (hop / rate * 1.5)
+            kick = (0.7 * np.sin(2.0 * math.pi * 58.0 * t) * np.exp(-((elapsed % 0.5) * 18.0)))
+            sweep_frequency = 90.0 * (2.0 ** ((elapsed % 8.0) / 8.0 * 7.0))
+            music = 0.17 * np.sin(2.0 * math.pi * sweep_frequency * t) + kick * float(beat)
+            pan = math.sin(elapsed * 0.7)
+            system_chunk = np.column_stack((music * (1.0 - 0.55 * pan), music * (1.0 + 0.55 * pan))).astype(np.float32)
+            talk_gate = 1.0 if 2.5 < (elapsed % 6.0) < 4.7 else 0.0
+            voice = talk_gate * 0.22 * (
+                np.sin(2.0 * math.pi * 180.0 * t) + 0.4 * np.sin(2.0 * math.pi * 540.0 * t)
+            )
+            mic_chunk = voice[:, None].astype(np.float32)
+            now = time.monotonic()
+            system = system_analyzer.push(system_chunk, now)
+            microphone = mic_analyzer.push(mic_chunk, now)
+            status = CaptureStatus("demo", "DEMO SIGNAL", 21.3, 0)
+            if system is not None:
+                self._publish_system(system, status)
+            if microphone is not None:
+                self._publish_microphone(microphone, status)
+            cursor += hop
+            self._demo_stop.wait(hop / rate)

--- a/audio/features.py
+++ b/audio/features.py
@@ -23,6 +23,16 @@ BAND_EDGES = (
     (7500.0, 16000.0),
 )
 
+SPECTRUM_BIN_COUNT = 48
+SPECTRUM_MIN_HZ = 35.0
+SPECTRUM_MAX_HZ = 16000.0
+SPECTRUM_EDGES = np.geomspace(
+    SPECTRUM_MIN_HZ,
+    SPECTRUM_MAX_HZ,
+    SPECTRUM_BIN_COUNT + 1,
+)
+SPECTRUM_FREQUENCIES = np.sqrt(SPECTRUM_EDGES[:-1] * SPECTRUM_EDGES[1:])
+
 
 @dataclass(frozen=True)
 class SourceFeatures:
@@ -30,6 +40,7 @@ class SourceFeatures:
     rms: float = 0.0
     peak: float = 0.0
     bands: tuple[float, ...] = (0.0,) * 8
+    spectrum: tuple[float, ...] = (0.0,) * SPECTRUM_BIN_COUNT
     centroid: float = 0.0
     flux: float = 0.0
     onset: bool = False
@@ -50,7 +61,15 @@ class SourceFeatures:
         return cls()
 
     def muted(self) -> "SourceFeatures":
-        return replace(self, active=False, rms=0.0, peak=0.0, bands=(0.0,) * 8, onset=False)
+        return replace(
+            self,
+            active=False,
+            rms=0.0,
+            peak=0.0,
+            bands=(0.0,) * 8,
+            spectrum=(0.0,) * SPECTRUM_BIN_COUNT,
+            onset=False,
+        )
 
 
 @dataclass(frozen=True)
@@ -94,6 +113,11 @@ class FeatureAnalyzer:
         self._band_masks = [
             (self._frequency >= low) & (self._frequency < min(high, self.sample_rate / 2.0))
             for low, high in BAND_EDGES
+        ]
+        self._spectrum_masks = [
+            (self._frequency >= low)
+            & (self._frequency < min(high, self.sample_rate / 2.0))
+            for low, high in zip(SPECTRUM_EDGES[:-1], SPECTRUM_EDGES[1:])
         ]
         self._pitch_mask = (self._frequency >= 55.0) & (self._frequency <= min(5000.0, self.sample_rate / 2.0))
 
@@ -153,6 +177,21 @@ class FeatureAnalyzer:
                 1.0,
             ))
             for normalizer, value in zip(self._band_ranges, raw_bands)
+        )
+        raw_spectrum = np.array(
+            [
+                float(np.sqrt(np.mean(power[mask]))) if np.any(mask) else 0.0
+                for mask in self._spectrum_masks
+            ],
+            dtype=float,
+        )
+        spectral_peak = max(float(raw_spectrum.max(initial=0.0)), 1e-12)
+        # Preserve the relative shape of each frame instead of independently
+        # normalizing fine bins, which would exaggerate leakage and noise.
+        spectrum_values = np.clip(
+            np.power(raw_spectrum / spectral_peak, 0.55) * math.sqrt(max(0.0, rms)),
+            0.0,
+            1.0,
         )
 
         useful = self._frequency <= min(16000.0, self.sample_rate / 2.0)
@@ -216,6 +255,7 @@ class FeatureAnalyzer:
             rms=rms,
             peak=peak,
             bands=band_values,
+            spectrum=tuple(float(value) for value in spectrum_values),
             centroid=centroid,
             flux=flux,
             onset=onset,

--- a/audio/features.py
+++ b/audio/features.py
@@ -1,0 +1,293 @@
+"""Realtime audio feature contracts and the NumPy analysis baseline."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, replace
+import math
+import time
+
+import numpy as np
+
+from .normalization import ActivityGate, AdaptiveRange
+
+
+BAND_EDGES = (
+    (35.0, 70.0),
+    (70.0, 140.0),
+    (140.0, 300.0),
+    (300.0, 700.0),
+    (700.0, 1600.0),
+    (1600.0, 3500.0),
+    (3500.0, 7500.0),
+    (7500.0, 16000.0),
+)
+
+
+@dataclass(frozen=True)
+class SourceFeatures:
+    active: bool = False
+    rms: float = 0.0
+    peak: float = 0.0
+    bands: tuple[float, ...] = (0.0,) * 8
+    centroid: float = 0.0
+    flux: float = 0.0
+    onset: bool = False
+    beat_phase: float = 0.0
+    tempo_bpm: float | None = None
+    tempo_confidence: float = 0.0
+    stereo_balance: float = 0.0
+    stereo_width: float = 0.0
+    pitch_classes: tuple[float, ...] = (0.0,) * 12
+    pitch_confidence: float = 0.0
+    octave_position: float = 0.5
+    spectral_flatness: float = 1.0
+    low_flux: float = 0.0
+    high_flux: float = 0.0
+
+    @classmethod
+    def silence(cls) -> "SourceFeatures":
+        return cls()
+
+    def muted(self) -> "SourceFeatures":
+        return replace(self, active=False, rms=0.0, peak=0.0, bands=(0.0,) * 8, onset=False)
+
+
+@dataclass(frozen=True)
+class AudioFeatureFrame:
+    sequence: int
+    monotonic_time: float
+    system: SourceFeatures
+    microphone: SourceFeatures
+    capture_latency_ms: float = 0.0
+    dropped_windows: int = 0
+
+    @classmethod
+    def silence(cls, sequence: int = 0) -> "AudioFeatureFrame":
+        return cls(sequence, time.monotonic(), SourceFeatures.silence(), SourceFeatures.silence())
+
+
+class FeatureAnalyzer:
+    """Stateful FFT, onset, beat, stereo, and pitch-class analyzer."""
+
+    def __init__(self, sample_rate=48000, channels=2, window_size=1024, hop_size=512):
+        self.sample_rate = int(sample_rate)
+        self.channels = max(1, int(channels))
+        self.window_size = int(window_size)
+        self.hop_size = int(hop_size)
+        # Zero padding improves pitch-class bin placement without increasing
+        # the capture window or its latency.
+        self.fft_size = max(4096, self.window_size)
+        self._window = np.hanning(self.window_size).astype(np.float32)
+        self._history = np.zeros((self.window_size, self.channels), dtype=np.float32)
+        self._received = 0
+        self._previous_magnitude = np.zeros(self.fft_size // 2 + 1, dtype=float)
+        self._last_time = None
+        self._last_onset = -1e9
+        self._onset_times = deque(maxlen=16)
+        self._flux_history = deque(maxlen=160)
+        self._rms_range = AdaptiveRange(minimum_ceiling=0.015)
+        self._peak_range = AdaptiveRange(minimum_ceiling=0.025)
+        self._band_ranges = [AdaptiveRange(minimum_ceiling=0.004) for _ in BAND_EDGES]
+        self._gate = ActivityGate()
+        self._frequency = np.fft.rfftfreq(self.fft_size, 1.0 / self.sample_rate)
+        self._band_masks = [
+            (self._frequency >= low) & (self._frequency < min(high, self.sample_rate / 2.0))
+            for low, high in BAND_EDGES
+        ]
+        self._pitch_mask = (self._frequency >= 55.0) & (self._frequency <= min(5000.0, self.sample_rate / 2.0))
+
+    def push(self, frames: np.ndarray, monotonic_time: float | None = None) -> SourceFeatures | None:
+        values = np.asarray(frames, dtype=np.float32)
+        if values.ndim == 1:
+            values = values.reshape(-1, 1)
+        if values.shape[1] != self.channels:
+            if values.shape[1] == 1 and self.channels > 1:
+                values = np.repeat(values, self.channels, axis=1)
+            else:
+                values = values[:, : self.channels]
+        count = values.shape[0]
+        if count >= self.window_size:
+            self._history[:] = values[-self.window_size :]
+        elif count:
+            self._history[:-count] = self._history[count:]
+            self._history[-count:] = values
+        self._received += count
+        if self._received < self.window_size:
+            return None
+        return self.analyze(self._history, monotonic_time=monotonic_time)
+
+    def analyze(self, frames: np.ndarray, monotonic_time: float | None = None) -> SourceFeatures:
+        now = time.monotonic() if monotonic_time is None else float(monotonic_time)
+        dt = self.hop_size / float(self.sample_rate) if self._last_time is None else max(1e-4, now - self._last_time)
+        self._last_time = now
+
+        values = np.asarray(frames, dtype=np.float32)
+        if values.ndim == 1:
+            values = values[:, None]
+        if values.shape[0] != self.window_size:
+            fixed = np.zeros((self.window_size, values.shape[1]), dtype=np.float32)
+            copy_count = min(self.window_size, values.shape[0])
+            fixed[-copy_count:] = values[-copy_count:]
+            values = fixed
+        mono = values.mean(axis=1, dtype=np.float64)
+        mono -= float(mono.mean())
+        peak_raw = float(np.max(np.abs(values), initial=0.0))
+        rms_raw = float(np.sqrt(np.mean(np.square(mono))))
+        rms = self._rms_range.update(rms_raw, dt)
+        peak = self._peak_range.update(peak_raw, dt)
+
+        spectrum = np.fft.rfft(mono * self._window, n=self.fft_size)
+        magnitude = np.abs(spectrum) * (2.0 / max(1.0, float(self._window.sum())))
+        power = magnitude * magnitude
+        raw_bands = []
+        for mask in self._band_masks:
+            raw_bands.append(float(np.sqrt(np.mean(power[mask]))) if np.any(mask) else 0.0)
+        dominant_band_energy = max(max(raw_bands, default=0.0), 1e-12)
+        band_values = tuple(
+            float(np.clip(
+                normalizer.update(value, dt)
+                * math.sqrt(max(0.0, rms))
+                * math.pow(value / dominant_band_energy, 0.65),
+                0.0,
+                1.0,
+            ))
+            for normalizer, value in zip(self._band_ranges, raw_bands)
+        )
+
+        useful = self._frequency <= min(16000.0, self.sample_rate / 2.0)
+        mag_sum = float(magnitude[useful].sum())
+        centroid_hz = (
+            float(np.sum(self._frequency[useful] * magnitude[useful]) / mag_sum)
+            if mag_sum > 1e-12 else 0.0
+        )
+        centroid = float(np.clip(centroid_hz / 16000.0, 0.0, 1.0))
+
+        positive = np.maximum(magnitude - self._previous_magnitude, 0.0)
+        previous_sum = float(self._previous_magnitude.sum())
+        # A transition out of true silence still needs to be an onset.  Using a
+        # small fraction of current energy as the denominator keeps that first
+        # attack finite while retaining the usual previous-frame flux ratio.
+        flux_denominator = max(1e-8, previous_sum, float(magnitude.sum()) * 0.05)
+        flux_raw = float(positive.sum() / flux_denominator)
+        low_mask = self._frequency < 300.0
+        high_mask = self._frequency >= 1600.0
+        low_flux_raw = float(positive[low_mask].sum() / max(
+            1e-8,
+            float(self._previous_magnitude[low_mask].sum()),
+            float(magnitude[low_mask].sum()) * 0.05,
+        ))
+        high_flux_raw = float(positive[high_mask].sum() / max(
+            1e-8,
+            float(self._previous_magnitude[high_mask].sum()),
+            float(magnitude[high_mask].sum()) * 0.05,
+        ))
+        self._previous_magnitude[:] = magnitude
+
+        self._flux_history.append(flux_raw)
+        flux_samples = np.fromiter(self._flux_history, dtype=float)
+        median_flux = float(np.median(flux_samples)) if len(flux_samples) else 0.0
+        mad = float(np.median(np.abs(flux_samples - median_flux))) if len(flux_samples) else 0.0
+        threshold = max(0.08, median_flux + 3.0 * mad)
+        onset = bool(
+            len(flux_samples) >= 4
+            and flux_raw > threshold
+            and rms > 0.07
+            and now - self._last_onset >= 0.08
+        )
+        if onset:
+            self._last_onset = now
+            self._onset_times.append(now)
+        flux = float(np.clip(flux_raw / max(threshold, 1e-6), 0.0, 1.0))
+        low_flux = float(np.clip(low_flux_raw / max(threshold, 1e-6), 0.0, 1.0))
+        high_flux = float(np.clip(high_flux_raw / max(threshold, 1e-6), 0.0, 1.0))
+
+        tempo_bpm, tempo_confidence, beat_phase = self._tempo(now)
+        stereo_balance, stereo_width = self._stereo(values)
+        flatness = self._flatness(magnitude[useful])
+        pitch_classes, pitch_confidence, octave_position = self._pitch(power)
+        voice_energy = sum(raw_bands[2:6])
+        total_band_energy = sum(raw_bands) + 1e-12
+        voice_ratio = float(np.clip(voice_energy / total_band_energy, 0.0, 1.0))
+        active = self._gate.update(rms, voice_ratio, dt) and rms_raw > 2e-5
+
+        return SourceFeatures(
+            active=active,
+            rms=rms,
+            peak=peak,
+            bands=band_values,
+            centroid=centroid,
+            flux=flux,
+            onset=onset,
+            beat_phase=beat_phase,
+            tempo_bpm=tempo_bpm,
+            tempo_confidence=tempo_confidence,
+            stereo_balance=stereo_balance,
+            stereo_width=stereo_width,
+            pitch_classes=pitch_classes,
+            pitch_confidence=pitch_confidence,
+            octave_position=octave_position,
+            spectral_flatness=flatness,
+            low_flux=low_flux,
+            high_flux=high_flux,
+        )
+
+    def _tempo(self, now: float) -> tuple[float | None, float, float]:
+        if len(self._onset_times) < 3:
+            return None, 0.0, 0.0
+        intervals = np.diff(np.fromiter(self._onset_times, dtype=float))
+        intervals = intervals[(intervals >= 0.25) & (intervals <= 1.5)]
+        if len(intervals) < 2:
+            return None, 0.0, 0.0
+        period = float(np.median(intervals))
+        consistency = 1.0 - float(np.clip(np.std(intervals) / max(period, 1e-6), 0.0, 1.0))
+        age = now - self._onset_times[-1]
+        freshness = float(np.clip(1.0 - max(0.0, age - period) / 2.0, 0.0, 1.0))
+        # Four accepted onsets yield three intervals, enough to establish a
+        # stable pulse while still rejecting inconsistent speech timing.
+        confidence = consistency * min(1.0, len(intervals) / 3.0) * freshness
+        return 60.0 / period, confidence, float((age / period) % 1.0)
+
+    @staticmethod
+    def _stereo(values: np.ndarray) -> tuple[float, float]:
+        if values.shape[1] < 2:
+            return 0.0, 0.0
+        left = values[:, 0].astype(float)
+        right = values[:, 1].astype(float)
+        left_rms = float(np.sqrt(np.mean(left * left)))
+        right_rms = float(np.sqrt(np.mean(right * right)))
+        total = left_rms + right_rms
+        if total <= 1e-9:
+            return 0.0, 0.0
+        balance = (right_rms - left_rms) / total
+        difference = float(np.sqrt(np.mean(np.square(left - right))))
+        width = float(np.clip(difference / max(total, 1e-9), 0.0, 1.0))
+        return float(np.clip(balance, -1.0, 1.0)), width
+
+    @staticmethod
+    def _flatness(magnitude: np.ndarray) -> float:
+        values = np.maximum(np.asarray(magnitude, dtype=float), 1e-12)
+        if not np.any(values > 1e-10):
+            return 1.0
+        return float(np.clip(np.exp(np.mean(np.log(values))) / np.mean(values), 0.0, 1.0))
+
+    def _pitch(self, power: np.ndarray) -> tuple[tuple[float, ...], float, float]:
+        frequencies = self._frequency[self._pitch_mask]
+        energies = power[self._pitch_mask]
+        total = float(energies.sum())
+        if total <= 1e-12:
+            return (0.0,) * 12, 0.0, 0.5
+        midi = 69.0 + 12.0 * np.log2(frequencies / 440.0)
+        nearest = np.rint(midi)
+        tuning_weight = np.exp(-0.5 * np.square((midi - nearest) / 0.24))
+        weighted = energies * tuning_weight
+        classes = np.zeros(12, dtype=float)
+        np.add.at(classes, np.mod(nearest.astype(int), 12), weighted)
+        class_total = float(classes.sum())
+        if class_total > 1e-12:
+            classes /= class_total
+        uniform = 1.0 / 12.0
+        confidence = float(np.clip((float(classes.max()) - uniform) / (1.0 - uniform), 0.0, 1.0))
+        octaves = np.clip((midi - 36.0) / 60.0, 0.0, 1.0)
+        octave_position = float(np.sum(octaves * energies) / total)
+        return tuple(float(x) for x in classes), confidence, octave_position

--- a/audio/normalization.py
+++ b/audio/normalization.py
@@ -1,0 +1,70 @@
+"""Adaptive level normalization and activity gating."""
+
+from __future__ import annotations
+
+from collections import deque
+import math
+
+import numpy as np
+
+
+class AdaptiveRange:
+    """Rolling robust 0..1 normalization with attack/release smoothing."""
+
+    def __init__(
+        self,
+        history: int = 400,
+        attack_seconds: float = 0.035,
+        release_seconds: float = 0.28,
+        minimum_ceiling: float = 1e-4,
+    ):
+        self.values = deque(maxlen=max(16, int(history)))
+        self.attack_seconds = max(1e-4, float(attack_seconds))
+        self.release_seconds = max(1e-4, float(release_seconds))
+        self.minimum_ceiling = max(1e-12, float(minimum_ceiling))
+        self.output = 0.0
+        self.floor = 0.0
+        self.ceiling = self.minimum_ceiling
+
+    def update(self, value: float, dt: float) -> float:
+        value = max(0.0, float(value))
+        self.values.append(value)
+        samples = np.fromiter(self.values, dtype=float)
+        if len(samples) >= 12:
+            self.floor = float(np.percentile(samples, 10.0))
+            self.ceiling = float(np.percentile(samples, 95.0))
+        else:
+            self.floor = 0.0
+            self.ceiling = max(self.minimum_ceiling, float(samples.max(initial=0.0)))
+        span = max(self.minimum_ceiling, self.ceiling - self.floor)
+        target = float(np.clip((value - self.floor) / span, 0.0, 1.0))
+        seconds = self.attack_seconds if target > self.output else self.release_seconds
+        alpha = 1.0 - math.exp(-max(0.0, dt) / seconds)
+        self.output += (target - self.output) * alpha
+        return float(np.clip(self.output, 0.0, 1.0))
+
+
+class ActivityGate:
+    """Hysteretic activity state with a short release hang time."""
+
+    def __init__(self, open_level: float = 0.085, close_level: float = 0.045, hang=0.2):
+        self.open_level = float(open_level)
+        self.close_level = float(close_level)
+        self.hang = float(hang)
+        self.active = False
+        self._quiet_for = 0.0
+
+    def update(self, level: float, voice_ratio: float, dt: float) -> bool:
+        evidence = float(level) * (0.65 + 0.35 * float(voice_ratio))
+        if not self.active and evidence >= self.open_level:
+            self.active = True
+            self._quiet_for = 0.0
+        elif self.active:
+            if evidence < self.close_level:
+                self._quiet_for += max(0.0, dt)
+                if self._quiet_for >= self.hang:
+                    self.active = False
+                    self._quiet_for = 0.0
+            else:
+                self._quiet_for = 0.0
+        return self.active

--- a/audio/ring_buffer.py
+++ b/audio/ring_buffer.py
@@ -1,0 +1,97 @@
+"""A small bounded audio ring buffer shared by capture and analysis threads."""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+
+
+class AudioRingBuffer:
+    """Preallocated, bounded FIFO for interleaved floating-point audio frames.
+
+    The capture callback never waits for the analyzer.  When the analyzer falls
+    behind, the oldest frames are discarded and ``dropped_frames`` records the
+    loss.  A short lock protects NumPy copies because callbacks and analysis run
+    on separate native threads.
+    """
+
+    def __init__(self, capacity_frames: int, channels: int):
+        if capacity_frames < 2:
+            raise ValueError("capacity_frames must be at least 2")
+        if channels < 1:
+            raise ValueError("channels must be positive")
+        self.capacity = int(capacity_frames)
+        self.channels = int(channels)
+        self._data = np.zeros((self.capacity, self.channels), dtype=np.float32)
+        self._read = 0
+        self._write = 0
+        self._size = 0
+        self._dropped_frames = 0
+        self._lock = threading.Lock()
+
+    @property
+    def available(self) -> int:
+        with self._lock:
+            return self._size
+
+    @property
+    def dropped_frames(self) -> int:
+        with self._lock:
+            return self._dropped_frames
+
+    def clear(self) -> None:
+        with self._lock:
+            self._read = 0
+            self._write = 0
+            self._size = 0
+
+    def write(self, frames: np.ndarray) -> None:
+        array = np.asarray(frames, dtype=np.float32)
+        if array.ndim == 1:
+            array = array.reshape(-1, self.channels)
+        if array.ndim != 2 or array.shape[1] != self.channels:
+            raise ValueError(f"expected frames shaped (n, {self.channels})")
+        count = int(array.shape[0])
+        if count == 0:
+            return
+
+        with self._lock:
+            if count >= self.capacity:
+                discarded = self._size + count - self.capacity
+                array = array[-self.capacity :]
+                count = self.capacity
+                self._read = 0
+                self._write = 0
+                self._size = 0
+                self._dropped_frames += max(0, discarded)
+
+            overflow = max(0, self._size + count - self.capacity)
+            if overflow:
+                self._read = (self._read + overflow) % self.capacity
+                self._size -= overflow
+                self._dropped_frames += overflow
+
+            first = min(count, self.capacity - self._write)
+            self._data[self._write : self._write + first] = array[:first]
+            remaining = count - first
+            if remaining:
+                self._data[:remaining] = array[first:]
+            self._write = (self._write + count) % self.capacity
+            self._size += count
+
+    def read(self, count: int) -> np.ndarray:
+        requested = max(0, int(count))
+        with self._lock:
+            count = min(requested, self._size)
+            result = np.empty((count, self.channels), dtype=np.float32)
+            if count == 0:
+                return result
+            first = min(count, self.capacity - self._read)
+            result[:first] = self._data[self._read : self._read + first]
+            remaining = count - first
+            if remaining:
+                result[first:] = self._data[:remaining]
+            self._read = (self._read + count) % self.capacity
+            self._size -= count
+            return result

--- a/docs/AUDIO_REACTIVE_ROADMAP.md
+++ b/docs/AUDIO_REACTIVE_ROADMAP.md
@@ -17,6 +17,7 @@ The cohesive baseline described here is implemented on the audio-reactivity bran
 
 - bounded callback ring buffers, WASAPI loopback, microphone capture, simultaneous independent streams, deterministic demo input, endpoint cycling, and automatic retry;
 - normalized FFT bands, multiscale levels, centroid, spectral flux, onset/refractory behavior, beat phase/confidence, stereo balance/width, pitch classes, octave position, and spectral flatness;
+- a 48-channel logarithmic spectral field and one unique acoustic identity per generated pyramid, including interpolated center frequency, bandwidth, harmonic/subharmonic mixture, mechanical response, damping, phase, and shared-edge coupling;
 - immutable formation topology, exact shared-edge adjacency, fallback proximity graphs, render-state bounds, 250 ms program crossfades, reduced motion, and exact 1.5-second silence reset;
 - Spectrum Crown, Beat Bloom, Conversation Orbit, Cinematic Weather, Game Radar, Signal Relay, and Harmonic Aurora;
 - switchboard source/program/device/response controls, privacy status, level meters, latency/drop telemetry, and preserved manual programs;
@@ -108,6 +109,7 @@ rainbowstarburst/
     __init__.py
     base.py             # AudioAnimation protocol and parameter schema
     director.py         # mode lifecycle and modulation composition
+    resonance.py        # unique per-pyramid acoustic identities and springs
     topology.py         # face normals, shared-edge graph, geodesic distances
     spectrum_crown.py
     beat_bloom.py
@@ -188,6 +190,8 @@ The first implementation should use NumPy only:
 8. detect onsets from adaptive spectral-flux thresholds with a refractory interval;
 9. estimate pulse from onset intervals only after a stable confidence threshold is met.
 
+The implemented analyzer also integrates 48 logarithmic spectral channels from 35 Hz to 16 kHz. These preserve fine spectral shape without independently amplifying leakage in quiet bins. Formation topology maps that field to a unique resonant center for every pyramid, interpolating between analysis channels when a formation has more than 48 members.
+
 SciPy `ShortTimeFFT` and `find_peaks` are optional upgrades after the NumPy baseline is profiled. Librosa is a reference for onset and beat behavior, not an initial real-time dependency.
 
 ### Latency and performance budget
@@ -216,6 +220,19 @@ All programs use the following channels so switching modes feels cohesive:
 - **rest:** an exact return to authored home geometry.
 
 The `AnimationDirector` owns these channels. A program emits target values, and the director applies clamping, attack/release, reduced-motion scaling, and return-to-rest behavior.
+
+### Organic pyramid resonance layer
+
+Every audio program is composed with the same micro-dynamics layer:
+
+1. Geometry-derived spiral order assigns distinct logarithmic center frequencies from 35 Hz to 16 kHz.
+2. Each pyramid receives deterministic bandwidth and fundamental, second-harmonic, third-harmonic, and subharmonic weights.
+3. The fine spectrum drives one underdamped spring per pyramid at a fixed 120 Hz simulation step.
+4. Individual stiffness, damping ratio, modulation phase, and motion rate prevent matched pyramids from moving as synchronized clones.
+5. Weak graph coupling transfers some energy across exact shared edges without overwhelming each pyramid's acoustic identity.
+6. The layer changes only apex/render channels, so joined Star bases and exported home geometry remain untouched.
+
+This layer sits beneath Spectrum Crown, Beat Bloom, Conversation Orbit, Cinematic Weather, Game Radar, Signal Relay, and Harmonic Aurora. Spectrum Crown gives it more visual weight; Signal Relay also injects its fine-frequency energy into the network simulation.
 
 Recommended hard bounds:
 

--- a/docs/AUDIO_REACTIVE_ROADMAP.md
+++ b/docs/AUDIO_REACTIVE_ROADMAP.md
@@ -1,0 +1,738 @@
+# Rainbow Starburst Audio-Reactive Roadmap
+
+## Purpose
+
+Rainbow Starburst should become a local, low-latency instrument that turns any sound on the computer into intentional motion across individually addressable pyramids. It must work with:
+
+- system output from a show, film, game, browser, music player, or voice-chat application;
+- a selected microphone;
+- system output and microphone at the same time;
+- silence, device changes, and unavailable audio hardware without destabilizing the visualization.
+
+This is an implementation plan, not a loose idea list. It defines the common architecture first, then specifies each creative program in terms of inputs, pyramid mapping, algorithms, controls, failure behavior, tests, and completion criteria.
+
+## Product principles
+
+1. **Every pyramid is an instrument.** Programs should use individual pyramid position, adjacency, normal, scale, apex extension, brightness, phase, and particle emission—not merely scale the whole model from one volume meter.
+2. **The original visual contract remains recognizable.** Resting wireframes stay white. Rainbow color belongs to moving signal paths and deliberate reactive accents rather than permanently assigning a random color to every pyramid.
+3. **Audio never mutates physical home coordinates.** Reactive motion is a transient render layer, like the repaired wave offset. Returning to silence must return every pyramid precisely to its authored formation.
+4. **The experience reacts to perception, not raw amplitude.** Adaptive noise floors, attack/release smoothing, logarithmic bands, onset detection, and bounded output ranges make a quiet conversation and a loud game equally expressive.
+5. **Capture is local and private.** Raw samples are analyzed in memory and discarded. Recording, transcription, networking, and speech recognition are out of scope unless added later as separate, explicit opt-in features.
+6. **Programs compose through one modulation system.** No mode writes directly into arbitrary physics fields. Each mode produces bounded channels that the animation director resolves consistently.
+
+## Supported audio sources
+
+### System output
+
+Use Windows WASAPI loopback in shared mode. WASAPI loopback captures the mix being played by a render endpoint even when the hardware has no dedicated “Stereo Mix” input. PyAudioWPatch exposes WASAPI loopback endpoints as input devices and provides helpers for finding the default speaker loopback device.
+
+Default behavior:
+
+- follow the default Windows output device;
+- offer explicit output-device selection;
+- reopen the stream after a default-device change;
+- show `SYSTEM: UNAVAILABLE` instead of failing the render loop;
+- analyze only; do not write a WAV file.
+
+### Microphone
+
+Open the selected capture endpoint as a second stream. Keep its gain normalization and noise floor independent from system output. This prevents loud speakers from burying a quiet microphone and enables programs that distinguish the two participants in a chat.
+
+Default behavior:
+
+- microphone source is off until selected;
+- remember the device identifier, not just its display name;
+- apply a conservative noise gate with hysteresis;
+- do not request exclusive access;
+- expose a clear live/muted indicator.
+
+### Both sources
+
+Do not mix microphone and system PCM buffers. Devices can have different clocks, sample rates, channel counts, and latencies. Analyze each source independently and combine their normalized feature frames inside the animation program.
+
+This also gives the visualization two semantic lanes:
+
+- `system`: the show, game, music, or remote participant;
+- `microphone`: the local participant or room.
+
+## Target technical architecture
+
+```mermaid
+flowchart LR
+    A["WASAPI loopback stream"] --> C["Preallocated system ring buffer"]
+    B["Microphone stream"] --> D["Preallocated microphone ring buffer"]
+    C --> E["System feature analyzer"]
+    D --> F["Microphone feature analyzer"]
+    E --> G["Immutable AudioFeatureFrame"]
+    F --> G
+    G --> H["AnimationDirector on render thread"]
+    I["Formation topology + pyramid home state"] --> H
+    H --> J["PerPyramidRenderState array"]
+    J --> K["OpenGL wireframes, rainbow trace, particles"]
+```
+
+### Thread boundaries
+
+- PortAudio callbacks only copy samples into preallocated single-producer/single-consumer buffers and increment overrun counters.
+- Analyzer workers read full windows, calculate features, and publish an immutable snapshot.
+- The pyglet/OpenGL thread reads one snapshot at the beginning of each frame.
+- Only the render thread updates animation state, controller state, pyglet objects, or OpenGL.
+- A full audio queue drops the oldest analysis window; it never blocks a PortAudio callback.
+
+### Proposed module layout
+
+```text
+rainbowstarburst/
+  audio/
+    __init__.py
+    devices.py          # endpoint enumeration, defaults, hot-plug recovery
+    capture.py          # PyAudioWPatch stream lifecycle
+    ring_buffer.py      # bounded preallocated SPSC audio buffers
+    features.py         # FFT bands, envelopes, flux, onset, stereo metrics
+    normalization.py    # noise floor, AGC, attack/release, silence state
+    engine.py           # source orchestration and feature snapshots
+  animations/
+    __init__.py
+    base.py             # AudioAnimation protocol and parameter schema
+    director.py         # mode lifecycle and modulation composition
+    topology.py         # face normals, shared-edge graph, geodesic distances
+    spectrum_crown.py
+    beat_bloom.py
+    conversation_orbit.py
+    cinematic_weather.py
+    game_radar.py
+    signal_relay.py
+    harmonic_aurora.py
+  tests/
+    fixtures/           # short generated signals only; no captured user audio
+```
+
+The repository can remain flat initially, but these packages should be introduced before audio modes accumulate in `pyramidGUI.py`.
+
+### Core data contracts
+
+```python
+@dataclass(frozen=True)
+class SourceFeatures:
+    active: bool
+    rms: float
+    peak: float
+    bands: tuple[float, ...]       # eight normalized log-frequency bands
+    centroid: float                # normalized 0..1
+    flux: float                    # positive spectral change
+    onset: bool
+    beat_phase: float              # 0..1, when confidence is sufficient
+    tempo_bpm: float | None
+    tempo_confidence: float
+    stereo_balance: float          # -1 left, +1 right
+    stereo_width: float            # 0 mono, 1 decorrelated/wide
+
+
+@dataclass(frozen=True)
+class AudioFeatureFrame:
+    sequence: int
+    monotonic_time: float
+    system: SourceFeatures
+    microphone: SourceFeatures
+    capture_latency_ms: float
+    dropped_windows: int
+
+
+@dataclass
+class PerPyramidRenderState:
+    radial_offset: float = 0.0
+    apex_scale: float = 1.0
+    uniform_scale: float = 1.0
+    rotation_offset: np.ndarray = field(default_factory=lambda: np.zeros(3))
+    line_alpha: float = 1.0
+    line_width: float = 1.0
+    accent_mix: float = 0.0
+    particle_rate: float = 0.0
+```
+
+Each formation also exposes immutable metadata:
+
+- home path and home transform;
+- outward normal;
+- spherical latitude and azimuth;
+- shared-edge neighbors;
+- connected-component and geodesic distance caches;
+- deterministic index and seeded variation value.
+
+### Feature extraction baseline
+
+Start at the device's native sample rate, normally 48 kHz. A 1,024-sample Hann window with a 512-sample hop gives approximately 21 ms of frequency context and an approximately 10.7 ms update cadence at 48 kHz.
+
+The first implementation should use NumPy only:
+
+1. remove DC and downmix analysis channels while retaining separate left/right energy;
+2. multiply by a cached Hann window;
+3. calculate `numpy.fft.rfft` magnitudes;
+4. integrate eight logarithmic bands: 35–70, 70–140, 140–300, 300–700, 700–1,600, 1,600–3,500, 3,500–7,500, and 7,500–16,000 Hz;
+5. calculate RMS, peak, centroid, positive spectral flux, stereo balance, and stereo width;
+6. update rolling 10th/95th-percentile floors and ceilings;
+7. normalize to 0–1, then apply per-feature attack/release smoothing;
+8. detect onsets from adaptive spectral-flux thresholds with a refractory interval;
+9. estimate pulse from onset intervals only after a stable confidence threshold is met.
+
+SciPy `ShortTimeFFT` and `find_peaks` are optional upgrades after the NumPy baseline is profiled. Librosa is a reference for onset and beat behavior, not an initial real-time dependency.
+
+### Latency and performance budget
+
+| Stage | Target |
+| --- | ---: |
+| Capture buffer | 5–11 ms |
+| Window/hop analysis delay | 11–22 ms |
+| Feature publication | under 2 ms |
+| Render pickup at 60 FPS | 0–17 ms |
+| Expected motion response | 30–55 ms |
+| Required p95 response | under 75 ms |
+
+At 1,280 pyramids, topology, band assignments, and home transforms must be cached. Per-frame work should be vectorized over NumPy arrays. New Python objects must not be created per pyramid per frame.
+
+## Shared animation grammar
+
+All programs use the following channels so switching modes feels cohesive:
+
+- **breath:** slow global or regional scale/radial motion;
+- **strike:** a short onset-driven impulse;
+- **travel:** an energy front moving over the adjacency graph;
+- **tip:** per-pyramid apex extension;
+- **signal:** the animated rainbow route;
+- **spark:** bounded particle emission;
+- **rest:** an exact return to authored home geometry.
+
+The `AnimationDirector` owns these channels. A program emits target values, and the director applies clamping, attack/release, reduced-motion scaling, and return-to-rest behavior.
+
+Recommended hard bounds:
+
+- radial offset: ±35% of formation core radius;
+- apex scale: 0.55–1.9;
+- uniform scale: 0.82–1.22;
+- rotation offset: ±18 degrees unless a mode explicitly owns global rotation;
+- particle count: existing global cap of 2,000;
+- silence return: within 1.5 seconds with no positional drift.
+
+## Creative program 1: Spectrum Crown
+
+### Experience
+
+The joined Star behaves like a living spectral sculpture. Bass moves broad foundational regions; mids articulate the body; high frequencies dance over small clusters. It should read as one sound distributed across 80 precise mechanical elements, not as a conventional bar equalizer wrapped around a sphere.
+
+### Audio mapping
+
+- Assign every pyramid one primary and one secondary log-frequency band using its normal, latitude, and a deterministic golden-angle ordering.
+- Low bands occupy broad polar caps with overlapping influence.
+- Mid bands wind around the equator.
+- High bands occupy smaller alternating clusters, making high-frequency detail visibly granular.
+- Blend 75% primary-band energy and 25% neighboring-band energy to avoid hard seams.
+
+### Per-pyramid motion
+
+- `apex_scale = 0.8 + 0.9 * band_energy^1.35`
+- `radial_offset = 0.16 * core_radius * smoothed_band_energy`
+- local attack/release varies slightly by deterministic seed, within a 20 ms range;
+- adjacent faces receive a 5% coupling term to keep bases visually cohesive.
+
+### Color and particles
+
+- Resting wireframes remain white.
+- The rainbow signal route seeks the loudest neighboring band and changes hue according to spectral centroid.
+- A high-confidence spectral-flux onset emits 2–12 particles from the currently dominant band cluster.
+
+### Controls
+
+- `BAND SPREAD`: narrow isolated clusters ↔ broad blended regions;
+- `REACTIVITY`: envelope attack/release preset;
+- `DEPTH`: apex/radial motion multiplier within safe bounds.
+
+### Implementation steps
+
+1. Cache frequency-band assignments in `animations/topology.py`.
+2. Add vectorized band-to-pyramid influence matrix with shape `[pyramids, bands]`.
+3. Implement target calculation without mutating home paths.
+4. Route rainbow traversal through the maximum-energy adjacency path.
+5. Add deterministic sine, dual-tone, and frequency-sweep tests.
+
+### Acceptance criteria
+
+- A 50 Hz sine moves only low-band regions after settling.
+- A 4 kHz sine moves high-band clusters and not the polar bass region.
+- A 50 Hz→12 kHz sweep visibly travels through the full formation in the documented order.
+- Silence returns every render state to identity within 1.5 seconds.
+- Changing formation recomputes assignment without index errors at 7, 20, 24, 80, 320, and 1,280 pyramids.
+
+## Creative program 2: Beat Bloom
+
+### Experience
+
+Rhythm opens the Star like a mechanical flower. Kicks compress and release the whole core, snares throw a traveling ring across alternating faces, and hats make only the tips flicker. When no stable beat exists, the program remains onset-reactive instead of inventing a tempo.
+
+### Audio mapping
+
+- kick evidence: 35–140 Hz energy plus low-band spectral flux;
+- snare evidence: 140–300 Hz body plus 1.6–7.5 kHz transient energy;
+- hat evidence: 3.5–16 kHz transient energy with low bass contribution;
+- beat phase: pulse-locked loop updated from accepted onsets;
+- confidence falls quickly when inter-onset intervals become inconsistent.
+
+### Per-pyramid motion
+
+- Kick: one 180–260 ms global compression/bloom envelope.
+- Snare: choose a deterministic seed face and propagate a geodesic ring one neighbor hop every 18–30 ms.
+- Hat: alternate parity groups for a 40–80 ms apex-tip shimmer.
+- Beat phase: apply a subtle continuous breath only when confidence exceeds 0.65.
+
+### Color and particles
+
+- The rainbow signal follows the snare ring.
+- Kicks momentarily brighten shared base edges without recoloring the resting wireframe.
+- Strong broadband onsets emit an outward particle shell with a per-onset cooldown.
+
+### Controls
+
+- `PULSE LOCK`: OFF / LOOSE / TIGHT;
+- `BLOOM`: kick depth;
+- `RIPPLE SPEED`: graph-hop duration.
+
+### Implementation steps
+
+1. Implement onset classification with confidence scores, not semantic labels.
+2. Add a beat tracker based on recent onset intervals and phase correction.
+3. Precompute all-pairs geodesic hop distances for formations up to 320 pyramids; use bounded breadth-first searches above that size.
+4. Implement reusable attack/hold/release envelopes.
+5. Verify behavior with generated kick, snare-like noise, hat-like noise, steady clicks, and arrhythmic impulses.
+
+### Acceptance criteria
+
+- Four-on-the-floor test audio locks within four beats and stays within ±40 ms phase error.
+- Arrhythmic speech never leaves a stale high-confidence tempo running longer than two seconds.
+- One onset launches one bounded ring; no frame-rate-dependent duplicate triggers occur.
+- Bases remain joined throughout the full Star bloom.
+
+## Creative program 3: Conversation Orbit
+
+### Experience
+
+For a call, stream, or in-person conversation, the Star becomes a two-sided social object. Computer audio occupies one hemisphere; the microphone occupies the opposite hemisphere. Turns illuminate and move toward the active speaker. Overlapping speech creates a bridge around the equator, while a clean handoff sends the rainbow signal from one side to the other.
+
+This mode analyzes activity and voice-like energy only. It does not identify speakers, recognize words, transcribe, or store audio.
+
+### Audio mapping
+
+- System and microphone use independent noise floors and activity gates.
+- Voice activity evidence combines RMS, 140–3,500 Hz energy ratio, spectral flatness proxy, and hang time.
+- System source maps to normals with positive X; microphone maps to negative X.
+- Each hemisphere retains a 15% contribution from the other source near the equator for visual continuity.
+
+### Per-pyramid motion
+
+- Active hemisphere tips extend toward its source direction.
+- Quiet hemisphere relaxes but never disappears.
+- A source transition launches a 350–700 ms rainbow handoff across the shortest adjacency path between hemisphere centroids.
+- Simultaneous activity lifts equatorial pyramids and creates a slow orbital rotation proportional to combined energy.
+
+### Color and particles
+
+- Source identity uses motion first.
+- System handoff starts at cool rainbow hues; microphone handoff starts at warm hues, both resolving into the full spectrum.
+- Laughter-like or excited broadband activity may increase spark density, but the UI labels this only as `HIGH ACTIVITY`, never as inferred emotion.
+
+### Controls
+
+- source selectors for system and microphone endpoints;
+- per-source sensitivity trim;
+- `HANDOFF`: subtle ↔ theatrical;
+- hard microphone mute on the console.
+
+### Implementation steps
+
+1. Support two simultaneous capture streams and independent analyzers.
+2. Add hysteretic source-activity state: quiet, attack, active, release.
+3. Partition any formation into two balanced connected regions.
+4. Implement handoff events from state transitions.
+5. Add synthetic alternating-speaker, overlap, fan-noise, and silence fixtures.
+
+### Acceptance criteria
+
+- Microphone activity never moves the system hemisphere more than its documented crossfade amount.
+- Alternating sources produce exactly one handoff per turn.
+- Continuous background fan noise settles below the activity threshold after calibration.
+- Muting the microphone closes its stream and zeroes its features immediately.
+
+## Creative program 4: Cinematic Weather
+
+### Experience
+
+This is the default program for television, film, ambient music, and mixed desktop audio. It avoids depending on a regular beat. The Star breathes with ambience, opens around dialogue-range energy, ripples with score changes, and throws a controlled shockwave on major impacts.
+
+### Audio mapping
+
+- 1.5-second integrated loudness proxy drives atmosphere.
+- 140–3,500 Hz presence drives an equatorial opening.
+- Sub-bass transient evidence drives impact shockwaves.
+- Spectral centroid controls whether activity concentrates toward lower or upper latitudes.
+- Stereo balance rotates the active weather front around the vertical axis.
+
+### Per-pyramid motion
+
+- Atmosphere: very slow ±6% radial breath.
+- Presence: equatorial apex opening with 120 ms attack and 450 ms release.
+- Impact: expanding spherical ring using geodesic distance from the lower-front seed region.
+- Score swell: coherent 2–4 second elevation wave based on long-term energy slope.
+
+### Color and particles
+
+- The normal signal trace remains rainbow.
+- Quiet scenes keep most wireframes white and calm.
+- Major low-frequency impacts emit a sparse shock shell; cooldown prevents explosion-heavy scenes from saturating the particle cap.
+
+### Controls
+
+- `SCENE ENERGY`: quiet / balanced / dramatic;
+- `DIALOGUE LIFT`: equatorial response amount;
+- `IMPACT LIMIT`: maximum shock frequency.
+
+### Implementation steps
+
+1. Add short, medium, and long envelope time scales.
+2. Implement energy-slope and low-transient detectors.
+3. Map stereo balance to a smoothed azimuth target.
+4. Reuse the graph ring from Beat Bloom with slower cinematic envelopes.
+5. Test against generated ambience, speech-band noise, sine sweeps, isolated impacts, and dense repeated impacts.
+
+### Acceptance criteria
+
+- Quiet ambience produces visible but non-distracting motion.
+- Dialogue-band fixtures open the equator without falsely triggering impact particles.
+- Repeated impacts respect the configured cooldown and global particle cap.
+- Mono input centers the weather front instead of jittering left/right.
+
+## Creative program 5: Game Radar
+
+### Experience
+
+Fast game audio becomes a readable directional energy field. Left/right transients strike the corresponding side of the Star and travel inward; bass impacts push broad regions; bright transients create sharp local needles. This is an audio visualization, not a gameplay-assistance classifier.
+
+### Audio mapping
+
+- Stereo balance determines left/right origin azimuth.
+- Stereo width determines how concentrated or broad the origin region is.
+- Low transient confidence drives broad impact ripples.
+- High transient confidence drives narrow needle strikes.
+- Broadband flux drives a multi-band burst.
+
+Stereo cannot reliably determine front/back position. The visual must present direction as a left/right energy bias unless a future multichannel backend provides additional channels.
+
+### Per-pyramid motion
+
+- Select an origin cap centered on the current stereo azimuth.
+- Inject a strike into that cap, then propagate through shared-edge neighbors.
+- Low strikes use broad radial displacement and long decay.
+- High strikes use apex extension and short decay.
+- Sustained engine/ambience energy becomes a low-amplitude background tremor, not repeated strikes.
+
+### Color and particles
+
+- Rainbow strike routes begin at the inferred side and fade along graph distance.
+- Particle direction follows the average normal of the origin cap.
+- Confidence controls opacity; ambiguous mono events remain centered.
+
+### Controls
+
+- `RADAR WIDTH`: narrow ↔ broad localization;
+- `IMPACT`: low-frequency depth;
+- `NEEDLE`: high-transient depth;
+- `FOCUS`: foreground transients ↔ full mix.
+
+### Implementation steps
+
+1. Preserve stereo channels through capture and calculate balance/width.
+2. Add frequency-conditioned transient confidence values.
+3. Build azimuth-to-face lookup tables for every formation.
+4. Reuse bounded graph propagation with mode-specific envelopes.
+5. Test left-only, right-only, centered, anti-phase, and mono signals.
+
+### Acceptance criteria
+
+- Left-only impulses originate on the left region and right-only impulses on the right.
+- Mono impulses remain centered.
+- Sustained tones do not retrigger onset effects each frame.
+- The UI never claims front/back or a specific game event from stereo evidence alone.
+
+## Creative program 6: Signal Relay
+
+### Experience
+
+The Star becomes a physical network. Sound energy enters selected pyramids and propagates over the exact shared-edge graph as a damped wave. Individual faces exchange energy with their neighbors, producing interference, echoes, and converging rainbow routes that could not be achieved with a global scale animation.
+
+This should be the signature “we control every pyramid” program.
+
+### Audio mapping
+
+- Each frequency band owns one deterministic injection node separated from the others by geodesic distance.
+- Band energy injects displacement at its node.
+- Onsets inject velocity, creating a traveling wave.
+- System and microphone can use two different seed sets.
+
+### Per-pyramid simulation
+
+For each node `i`, keep displacement `u[i]` and velocity `v[i]`:
+
+```text
+acceleration[i] = coupling * Σ(u[j] - u[i]) - damping * v[i] + audio_input[i]
+velocity[i]    += acceleration[i] * dt
+displacement[i] += velocity[i] * dt
+```
+
+Use a fixed 120 Hz simulation step with an accumulator, a bounded number of catch-up steps, and stable coupling/damping presets. Convert displacement into apex scale and a smaller radial offset. Never integrate it into physical home position.
+
+### Color and particles
+
+- The rainbow route follows the steepest positive-energy neighbor from the strongest injection node.
+- Constructive interference briefly increases white-line brightness.
+- Only strong, isolated wave collisions emit particles.
+
+### Controls
+
+- `COUPLING`: independent tips ↔ rigid shell;
+- `DAMPING`: long echoes ↔ tight response;
+- `INJECTION`: audio force;
+- `SOURCE SPLIT`: shared seeds ↔ separate system/microphone networks.
+
+### Implementation steps
+
+1. Build a compact adjacency list from shared base edges.
+2. Implement the fixed-step damped wave simulation with vectorized arrays.
+3. Add deterministic band seed selection.
+4. Implement energy-route tracing with loop prevention.
+5. Add conservation/stability tests with impulses, silence, variable render `dt`, and 1,280 nodes.
+
+### Acceptance criteria
+
+- An impulse visibly reaches graph neighbors in increasing hop order.
+- The simulation returns below 1% displacement after the preset decay interval.
+- Results remain equivalent within tolerance at 30, 60, and 144 render FPS.
+- No NaN, unbounded amplitude, or home-position drift occurs during a ten-minute stress test.
+
+## Creative program 7: Harmonic Aurora
+
+### Experience
+
+Tonal sound paints stable harmonic regions while noisy sound dissolves into roaming light. Notes and chords create recognizable constellations across the Star; pitch changes rotate the constellation instead of simply increasing movement.
+
+### Audio mapping
+
+- Estimate 12 pitch-class energies using harmonic summation over FFT bins.
+- Map pitch classes clockwise around azimuth.
+- Map octave energy from lower to upper latitude.
+- Spectral flatness controls constellation coherence: tonal audio is localized, noisy audio is diffuse.
+- Require confidence before showing a named pitch class in diagnostics; the visual itself can interpolate continuously.
+
+### Per-pyramid motion
+
+- Active pitch classes lift their azimuth sectors.
+- Octave distribution shifts the lift vertically.
+- Chords activate multiple connected arcs.
+- Pitch changes send a smooth rainbow rotation along the shortest circular direction.
+
+### Color and particles
+
+- Hue follows pitch-class angle but resolves through the existing rainbow spectrum.
+- Stable tones produce no particles by default.
+- Note onsets can release a small spark at the sector centroid.
+
+### Controls
+
+- `TONAL FOCUS`: strict pitch confidence ↔ permissive color field;
+- `HARMONICS`: fundamental-only ↔ overtone-rich;
+- `GLIDE`: pitch transition smoothing.
+
+### Implementation steps
+
+1. Add harmonic-summation pitch-class features to the analyzer.
+2. Validate against generated notes over multiple octaves and amplitudes.
+3. Build pitch-class/latitude influence matrices.
+4. Add chord and glissando fixtures.
+5. Profile before considering a constant-Q or librosa-based optional backend.
+
+### Acceptance criteria
+
+- A4 and A5 activate the same azimuth family at different latitudes.
+- Major-triad fixtures activate three stable sectors.
+- White noise remains diffuse and does not report high pitch confidence.
+- A continuous glissando rotates smoothly without snapping or flicker.
+
+## Switchboard integration
+
+Add an `AUDIO REACTIVE` bank without removing manual WAVE, SPIN, PULSE, and NONE.
+
+### Primary controls
+
+- source: OFF / SYSTEM / MIC / BOTH;
+- program: CROWN / BLOOM / ORBIT / CINEMA / RADAR / RELAY / AURORA;
+- reactivity: CALM / BALANCED / LIVE;
+- sensitivity trim;
+- reduced motion;
+- device/status drawer.
+
+### Required status feedback
+
+- selected endpoint names;
+- `LIVE ANALYSIS — NOT RECORDING` privacy copy;
+- per-source level and activity indicators;
+- loopback/microphone unavailable state;
+- buffer overrun count when nonzero;
+- measured analysis/render latency;
+- active program and fallback state.
+
+### Mode transitions
+
+1. Fade the outgoing program's modulation weight to zero over 250 ms.
+2. Reset its internal state.
+3. Start the incoming program from identity render states.
+4. Fade in over 250 ms.
+5. Manual NONE always wins immediately and returns to authored geometry.
+
+## Implementation sequence
+
+### Milestone 1 — Capture foundation
+
+- Add PyAudioWPatch as the Windows audio dependency.
+- Enumerate input and WASAPI loopback endpoints.
+- Implement start/stop/reconnect lifecycle and preallocated ring buffers.
+- Publish RMS/peak-only feature frames.
+- Add a diagnostic console command and simulated-source backend.
+
+Exit gate: system output and microphone can run separately and together for 30 minutes with no callback exception, memory growth, or renderer stall.
+
+### Milestone 2 — Feature engine
+
+- Add FFT bands, centroid, flux, onset, stereo metrics, noise floors, AGC, and smoothing.
+- Add deterministic generated-signal tests.
+- Add feature telemetry overlay behind a debug flag.
+
+Exit gate: every feature has a unit test and remains normalized under silence, quiet audio, clipping, and device-native sample rates.
+
+### Milestone 3 — Per-pyramid render layer
+
+- Separate immutable home geometry from transient render state.
+- Generate face normals and adjacency metadata for every formation.
+- Add `AnimationDirector`, program lifecycle, bounds, reduced motion, and identity reset.
+
+Exit gate: ten minutes of synthetic modulation creates zero permanent position/rotation drift.
+
+### Milestone 4 — First complete programs
+
+Implement in this order:
+
+1. Spectrum Crown — validates bands and influence matrices.
+2. Cinematic Weather — validates multiscale envelopes and non-beat content.
+3. Signal Relay — validates adjacency and individual-pyramid simulation.
+4. Beat Bloom — adds robust onset/pulse behavior.
+5. Conversation Orbit — adds dual-source semantics.
+6. Game Radar — adds stereo localization.
+7. Harmonic Aurora — adds pitch-class analysis.
+
+Every program lands with its own synthetic fixtures, controls, fallback behavior, and acceptance checklist.
+
+### Milestone 5 — Product hardening
+
+- endpoint hot-plug and default-device changes;
+- saved settings with safe defaults;
+- UI accessibility and keyboard control;
+- reduced-motion profile;
+- 30/60/144 FPS determinism checks;
+- long-run memory/latency telemetry;
+- packaging and clean-install verification on Windows 10 and Windows 11.
+
+## Pull-request decomposition
+
+Keep implementation reviewable with this dependency order:
+
+1. `audio: add device enumeration and simulated source`
+2. `audio: add WASAPI loopback and microphone capture`
+3. `audio: add normalized realtime feature engine`
+4. `animation: add immutable per-pyramid render state`
+5. `animation: add formation topology and adjacency cache`
+6. `ui: add audio source controls and privacy status`
+7. `animation: add Spectrum Crown`
+8. `animation: add Cinematic Weather`
+9. `animation: add Signal Relay`
+10. `animation: add Beat Bloom`
+11. `animation: add Conversation Orbit`
+12. `animation: add Game Radar`
+13. `animation: add Harmonic Aurora`
+14. `quality: add hot-plug, performance, and long-run tests`
+
+No creative program PR should bypass the common render layer or introduce its own capture thread.
+
+## Test strategy
+
+### Unit tests
+
+- exact band response for generated sine waves;
+- RMS/peak normalization and clipping;
+- onset count and refractory behavior;
+- beat phase and confidence decay;
+- stereo balance/width;
+- pitch-class confidence;
+- topology adjacency, connectivity, and geodesic distances;
+- render-state clamping and identity reset;
+- fixed-step wave stability.
+
+### Integration tests
+
+- simulated system and microphone streams at different sample rates;
+- stream start/stop and endpoint loss;
+- queue overrun without callback blocking;
+- switching source and program during active audio;
+- switching formations at every supported pyramid count;
+- manual animation ↔ audio program transitions;
+- export synchronization remains independent from render modulation.
+
+### Visual acceptance recordings
+
+Record short test runs using generated audio only:
+
+- bass-to-treble sweep for Spectrum Crown;
+- steady beat then arrhythmic speech for Beat Bloom;
+- alternating/overlapping sources for Conversation Orbit;
+- ambience/dialogue/impact sequence for Cinematic Weather;
+- left/center/right impulses for Game Radar;
+- single impulse propagation for Signal Relay;
+- chromatic scale and chord for Harmonic Aurora.
+
+### Long-run checks
+
+- 30 minutes with both real sources;
+- ten minutes at Globe detail 3 (1,280 pyramids);
+- repeated device disconnect/reconnect;
+- silence for five minutes after high-energy input;
+- memory, callback overruns, analysis latency, render FPS, and particle count logged.
+
+## Definition of done for the audio-reactive system
+
+The overall feature is complete only when:
+
+- system output, microphone, and both-source modes work on supported Windows systems;
+- no raw audio is saved or transmitted;
+- every program uses the shared feature and modulation contracts;
+- every program has deterministic synthetic tests and documented controls;
+- silence returns all pyramids exactly to home state;
+- source loss degrades to a visible safe state without closing either window;
+- p95 reaction latency is under 75 ms on the reference machine;
+- the 1,280-pyramid formation maintains the agreed minimum frame rate;
+- switching formations still produces the exact managed pyramid-file count;
+- a clean installation can launch, select an endpoint, and run every program using only documented steps.
+
+## Primary technical references
+
+- [Microsoft: WASAPI loopback recording](https://learn.microsoft.com/en-us/windows/win32/coreaudio/loopback-recording)
+- [PyAudioWPatch repository and supported WASAPI helpers](https://github.com/s0d3s/PyAudioWPatch)
+- [PyAudioWPatch loopback capture example](https://github.com/s0d3s/PyAudioWPatch/blob/master/examples/pawp_record_wasapi_loopback.py)
+- [NumPy real FFT (`numpy.fft.rfft`)](https://numpy.org/doc/stable/reference/generated/numpy.fft.rfft.html)
+- [SciPy `ShortTimeFFT`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ShortTimeFFT.html)
+- [SciPy peak finding](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.find_peaks.html)
+- [Librosa onset detection](https://librosa.org/doc/0.11.0/onset.html)
+- [Librosa beat and tempo tools](https://librosa.org/doc/0.11.0/beat.html)

--- a/docs/AUDIO_REACTIVE_ROADMAP.md
+++ b/docs/AUDIO_REACTIVE_ROADMAP.md
@@ -9,7 +9,20 @@ Rainbow Starburst should become a local, low-latency instrument that turns any s
 - system output and microphone at the same time;
 - silence, device changes, and unavailable audio hardware without destabilizing the visualization.
 
-This is an implementation plan, not a loose idea list. It defines the common architecture first, then specifies each creative program in terms of inputs, pyramid mapping, algorithms, controls, failure behavior, tests, and completion criteria.
+This document is the design and acceptance specification for the implemented system. It defines the common architecture first, then specifies each creative program in terms of inputs, pyramid mapping, algorithms, controls, failure behavior, tests, and completion criteria.
+
+## Implementation status
+
+The cohesive baseline described here is implemented on the audio-reactivity branch:
+
+- bounded callback ring buffers, WASAPI loopback, microphone capture, simultaneous independent streams, deterministic demo input, endpoint cycling, and automatic retry;
+- normalized FFT bands, multiscale levels, centroid, spectral flux, onset/refractory behavior, beat phase/confidence, stereo balance/width, pitch classes, octave position, and spectral flatness;
+- immutable formation topology, exact shared-edge adjacency, fallback proximity graphs, render-state bounds, 250 ms program crossfades, reduced motion, and exact 1.5-second silence reset;
+- Spectrum Crown, Beat Bloom, Conversation Orbit, Cinematic Weather, Game Radar, Signal Relay, and Harmonic Aurora;
+- switchboard source/program/device/response controls, privacy status, level meters, latency/drop telemetry, and preserved manual programs;
+- deterministic tests spanning generated signals, topology, render invariants, all program/formation combinations, and fixed-step frame-rate equivalence.
+
+The milestone and pull-request sections remain below as architectural history and a checklist for future refinement. Real-hardware endurance and installer validation should still be repeated for every release machine.
 
 ## Product principles
 
@@ -79,7 +92,7 @@ flowchart LR
 - Only the render thread updates animation state, controller state, pyglet objects, or OpenGL.
 - A full audio queue drops the oldest analysis window; it never blocks a PortAudio callback.
 
-### Proposed module layout
+### Implemented module layout
 
 ```text
 rainbowstarburst/

--- a/mastercontroller.py
+++ b/mastercontroller.py
@@ -35,6 +35,7 @@ PARTICLE_LOW    = "LOW"
 PARTICLE_MEDIUM = "MEDIUM"
 PARTICLE_HEAVY  = "HEAVY"
 MAX_PARTICLES   = 2000
+MAX_GLOBE_SUBDIVISIONS = 3
 
 class Particle:
     """
@@ -74,6 +75,12 @@ def generate_icosahedron_faces(subdivisions=0):
     The result is a list of triangular faces that can be used to place triangular pyramids
     around an invisible core.
     """
+    try:
+        subdivisions = int(subdivisions)
+    except (TypeError, ValueError):
+        subdivisions = 0
+    subdivisions = max(0, min(MAX_GLOBE_SUBDIVISIONS, subdivisions))
+
     # Basic icosahedron coordinates (golden ratio approach)
     t  = (1.0 + math.sqrt(5.0)) / 2.0
     verts = [
@@ -140,6 +147,22 @@ def normalize_vec(v):
         return v
     return v/d
 
+
+def rotation_aligning_apex(direction):
+    """Return Euler angles that rotate local +Y toward ``direction``.
+
+    ``Pyramid.transform_path`` applies ``Rz @ Ry @ Rx``.  Holding yaw at zero
+    gives a stable two-angle solution and avoids the half-sphere collapse caused
+    by leaving every spike upright.
+    """
+    direction = normalize_vec(np.asarray(direction, dtype=float))
+    if np.linalg.norm(direction) < 1e-9:
+        return np.zeros(3, dtype=float)
+    x, y, z = direction
+    pitch = math.degrees(math.asin(max(-1.0, min(1.0, z))))
+    roll = math.degrees(math.atan2(-x, y))
+    return np.array([pitch, 0.0, roll], dtype=float)
+
 ###############################################################################
 # MASTER CONTROLLER
 ###############################################################################
@@ -150,7 +173,7 @@ class MasterController:
     that creates triangular-based pyramids around a subdivided icosahedron for
     a 'globe' shape with minimal overlap and apex outward from the core.
     """
-    def __init__(self):
+    def __init__(self, export_directory="Pyramids"):
         self.pyramids = []
         self.particles= []
         self.current_particle_mode = PARTICLE_OFF
@@ -158,8 +181,10 @@ class MasterController:
         self.user_sphere_pos    = np.array([0,0,0],dtype=float)
         self.user_sphere_radius = 0.5
 
-        # ensure subdir
-        os.makedirs("Pyramids", exist_ok=True)
+        # Keep generated definitions in one resolved directory.  The exporter
+        # only manages files matching ``pyramid_<integer>.txt`` inside it.
+        self.export_directory = os.path.abspath(export_directory)
+        os.makedirs(self.export_directory, exist_ok=True)
 
         # export management configuration
         self.export_enabled = True
@@ -194,7 +219,7 @@ class MasterController:
           animation mode or do it manually.
         - We store each pyramid => 'Pyramids/pyramid_{ID}.txt' with unique ID.
         """
-        self.clear_pyramids()
+        self.clear_pyramids(prune_exports=False)
 
         faces = generate_icosahedron_faces(subdivisions=subdivisions)
         pid = start_id
@@ -245,12 +270,16 @@ class MasterController:
 
             # store custom path
             p.local_path = custom_path
+            p.physics.gravity = 0.0
+            p.physics.ground_collision_enabled = False
 
             # We'll place the pyramid's physics.position= [0,0,0], no wave by default.
             # if you want wave/spin, do set_animation_mode(...) or individually set it.
 
             self.pyramids.append(p)
             self.export_pyramid_file(p)
+
+        self.sync_export_files()
 
     def init_edge_to_edge_pyramids(self,
                                    count=5,
@@ -261,9 +290,10 @@ class MasterController:
         """
         The older method => line arrangement
         """
-        self.clear_pyramids()
+        self.clear_pyramids(prune_exports=False)
 
         x_offset= base_length
+        start_x = -(count - 1) * x_offset / 2.0
         for i in range(count):
             pid= i+1
             p= Pyramid(
@@ -273,13 +303,17 @@ class MasterController:
                 base_width  = base_width,
                 apex_height = apex_height
             )
-            p.physics.position[0]= i*x_offset
+            p.physics.position[0]= start_x + i*x_offset
+            p.physics.gravity=0.0
+            p.physics.ground_collision_enabled=False
             # wave
             p.physics.wave_axis_enable["y"]=True
             p.physics.wave_phase["y"]= i*wave_offset
             p.physics.wave_amplitude["y"]=0.5
             self.pyramids.append(p)
             self.export_pyramid_file(p)
+
+        self.sync_export_files()
 
     def init_spike_sphere_pyramids(self,
                                    count=8,
@@ -290,8 +324,10 @@ class MasterController:
         """
         The older spike approach => random fibonacci faces
         """
-        self.clear_pyramids()
-        if count<1:return
+        self.clear_pyramids(prune_exports=False)
+        if count<1:
+            self.sync_export_files()
+            return
 
         phi= math.pi*(3.0- math.sqrt(5.0))
         for i in range(count):
@@ -315,6 +351,9 @@ class MasterController:
                 apex_height  = apex_height
             )
             p.physics.position= dir_vec*sphere_radius
+            p.physics.rotation= rotation_aligning_apex(dir_vec)
+            p.physics.gravity=0.0
+            p.physics.ground_collision_enabled=False
             # apex outward => wave off
             p.physics.wave_axis_enable["x"]=False
             p.physics.wave_axis_enable["y"]=False
@@ -322,6 +361,8 @@ class MasterController:
 
             self.pyramids.append(p)
             self.export_pyramid_file(p)
+
+        self.sync_export_files()
 
     def init_grid_pyramids(self,
                            rows=3,
@@ -334,7 +375,7 @@ class MasterController:
         """
         The older 2D grid approach
         """
-        self.clear_pyramids()
+        self.clear_pyramids(prune_exports=False)
         pid=1
         start_x= -(cols-1)*spacing_x/2
         start_z= -(rows-1)*spacing_z/2
@@ -351,6 +392,8 @@ class MasterController:
                 px= start_x + c* spacing_x
                 pz= start_z + r* spacing_z
                 p.physics.position= np.array([px,0,pz],dtype=float)
+                p.physics.gravity=0.0
+                p.physics.ground_collision_enabled=False
                 # wave on y
                 p.physics.wave_axis_enable["y"]=True
                 p.physics.wave_phase["y"]= (r+c)*0.3
@@ -359,81 +402,69 @@ class MasterController:
                 self.pyramids.append(p)
                 self.export_pyramid_file(p)
 
+        self.sync_export_files()
+
     def init_star_formation(self,
-                            count=5,
-                            radius=5.0,
-                            inner_radius=None,
-                            base_length=1.0,
-                            base_width=1.0,
-                            apex_height=2.0):
-        """Arrange pyramids along a classic star polygon footprint.
+                            subdivisions=1,
+                            core_radius=3.0,
+                            spike_height=2.4,
+                            start_id=1):
+        """Build a closed, full star from edge-sharing radial pyramids.
 
-        We alternate between ``radius`` (outer points) and ``inner_radius`` to create a
-        star-like loop on the XZ plane.  Each pyramid is placed upright and rotated so
-        that its local +Z axis points away from the origin, helping the formation feel
-        cohesive in the visualization.
+        The bases are the triangular faces of one subdivided icosahedral core.
+        Adjacent pyramids therefore share the exact same base edge instead of
+        floating at unrelated Fibonacci-sphere positions.  Every apex extends
+        outward from its face, producing a joined SpikeSphere / full star.
 
-        Args:
-            count: Number of outer points in the star.  The total number of pyramids is
-                ``count * 2`` because we add an inner point between every pair of outer
-                points.
-            radius: Distance from the origin for the outer points.
-            inner_radius: Distance for the inner points.  Defaults to half of
-                ``radius`` if not provided.
-            base_length/base_width/apex_height: Pyramid geometry parameters.
+        ``subdivisions=0`` creates 20 broad spikes and ``subdivisions=1`` creates
+        80 finer spikes.  The global safety limit also applies here.
         """
-        self.clear_pyramids()
+        self.clear_pyramids(prune_exports=False)
 
-        if count < 2:
-            return
+        faces = generate_icosahedron_faces(subdivisions=subdivisions)
+        pid = int(start_id)
+        for v1, v2, v3 in faces:
+            c1 = np.asarray(v1, dtype=float) * core_radius
+            c2 = np.asarray(v2, dtype=float) * core_radius
+            c3 = np.asarray(v3, dtype=float) * core_radius
+            face_center = (c1 + c2 + c3) / 3.0
+            face_normal = normalize_vec(face_center)
+            apex = face_center + face_normal * spike_height
 
-        if inner_radius is None:
-            inner_radius = radius * 0.5
+            p = Pyramid(
+                pyramid_id=pid,
+                num_corners=3,
+                base_length=core_radius,
+                base_width=core_radius,
+                apex_height=spike_height,
+            )
+            pid += 1
 
-        pid = 1
-        angle_step = (2.0 * math.pi) / float(count)
+            # A continuous path around the shared triangular base and out along
+            # every spike edge.  The base vertices are reused verbatim between
+            # neighboring faces, which is what guarantees edge-to-edge contact.
+            p.local_path = [
+                c1, c2, c3, c1,
+                apex, c2, apex, c3, apex, c1,
+            ]
+            p.physics.gravity = 0.0
+            p.physics.ground_collision_enabled = False
 
-        for i in range(count):
-            outer_angle = i * angle_step
-            inner_angle = outer_angle + angle_step / 2.0
+            self.pyramids.append(p)
+            self.export_pyramid_file(p)
 
-            outer_pos = np.array([
-                math.cos(outer_angle) * radius,
-                0.0,
-                math.sin(outer_angle) * radius,
-            ], dtype=float)
-
-            inner_pos = np.array([
-                math.cos(inner_angle) * inner_radius,
-                0.0,
-                math.sin(inner_angle) * inner_radius,
-            ], dtype=float)
-
-            for pos in (outer_pos, inner_pos):
-                p = Pyramid(
-                    pyramid_id=pid,
-                    num_corners=4,
-                    base_length=base_length,
-                    base_width=base_width,
-                    apex_height=apex_height,
-                )
-                pid += 1
-
-                p.physics.position = pos
-                radial_norm = math.hypot(pos[0], pos[2])
-                yaw = math.degrees(math.atan2(pos[0], pos[2])) if radial_norm > 1e-9 else 0.0
-                p.physics.rotation[1] = yaw
-
-                self.pyramids.append(p)
-                self.export_pyramid_file(p)
+        self.sync_export_files()
 
     # ------------------------------------------------------------------------
     # MULTI-PYRAMID MANAGEMENT
     # ------------------------------------------------------------------------
-    def clear_pyramids(self):
+    def clear_pyramids(self, prune_exports=True):
         self.pyramids=[]
+        self.particles=[]
         if self.export_async:
             self._export_queue.clear()
+        if prune_exports:
+            self.sync_export_files()
 
     def add_pyramid(self, **kwargs):
         """
@@ -458,6 +489,7 @@ class MasterController:
             return
         targ.set_pyramid_id(new_id)
         self.export_pyramid_file(targ)
+        self.sync_export_files()
 
     def replicate_pyramid(self, source_id, new_id):
         src=None
@@ -491,6 +523,7 @@ class MasterController:
         clone.physics.gravity          = src.physics.gravity
         clone.physics.bounce_factor    = src.physics.bounce_factor
         clone.physics.mass             = src.physics.mass
+        clone.physics.ground_collision_enabled = src.physics.ground_collision_enabled
 
         # if custom local_path was set => also replicate that
         # e.g. for triangular face pyramids
@@ -502,6 +535,7 @@ class MasterController:
 
     def remove_pyramid(self, pyramid_id):
         self.pyramids= [p for p in self.pyramids if p.pyramid_id != pyramid_id]
+        self.sync_export_files()
 
     # ------------------------------------------------------------------------
     # EXPORT CONFIGURATION
@@ -557,15 +591,51 @@ class MasterController:
             self._write_pyramid_file(pyramid)
             processed += 1
 
+    def sync_export_files(self):
+        """Remove stale managed exports so the directory mirrors the live scene.
+
+        Only exact ``pyramid_<integer>.txt`` files in ``export_directory`` are
+        touched.  Other files and subdirectories are deliberately ignored.
+        """
+        if not self.export_enabled:
+            return
+
+        active_ids = {int(p.pyramid_id) for p in self.pyramids}
+        try:
+            entries = os.scandir(self.export_directory)
+        except FileNotFoundError:
+            os.makedirs(self.export_directory, exist_ok=True)
+            return
+
+        with entries:
+            for entry in entries:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                name = entry.name
+                if not (name.startswith("pyramid_") and name.endswith(".txt")):
+                    continue
+                id_text = name[len("pyramid_"):-len(".txt")]
+                if not id_text.isdigit():
+                    continue
+                if int(id_text) not in active_ids:
+                    os.remove(entry.path)
+
     # ------------------------------------------------------------------------
     # ANIMATION
     # ------------------------------------------------------------------------
     def set_animation_mode(self, mode):
+        # Animation modes are mutually exclusive.  The old implementation left
+        # angular velocity running when switching from SPIN to WAVE/PULSE.
+        for p in self.pyramids:
+            p.physics.wave_axis_enable["x"]=False
+            p.physics.wave_axis_enable["y"]=False
+            p.physics.wave_axis_enable["z"]=False
+            p.physics.wave_offset[:]=0.0
+            p.physics.angular_velocity[:]=0.0
+
         if mode== ANIMATION_WAVE_Y:
             for p in self.pyramids:
-                p.physics.wave_axis_enable["x"]=False
                 p.physics.wave_axis_enable["y"]=True
-                p.physics.wave_axis_enable["z"]=False
                 p.physics.wave_amplitude["y"]=1.0
                 p.physics.wave_frequency["y"]=1.0
         elif mode== ANIMATION_SPIN:
@@ -576,13 +646,6 @@ class MasterController:
                 p.physics.wave_axis_enable["y"]=True
                 p.physics.wave_amplitude["y"]=2.0
                 p.physics.wave_frequency["y"]=2.0
-        else:
-            # disable wave/spin
-            for p in self.pyramids:
-                p.physics.wave_axis_enable["x"]=False
-                p.physics.wave_axis_enable["y"]=False
-                p.physics.wave_axis_enable["z"]=False
-                p.physics.angular_velocity[:]=0.0
 
     # ------------------------------------------------------------------------
     # UPDATE
@@ -742,9 +805,8 @@ class MasterController:
         Writes param & labeling => "Pyramids/pyramid_{p.pyramid_id}.txt"
         capturing shape & physics state.
         """
-        subdir="Pyramids"
         fname= f"pyramid_{p.pyramid_id}.txt"
-        path= os.path.join(subdir,fname)
+        path= os.path.join(self.export_directory,fname)
 
         with open(path,"w") as f:
             f.write(f"** Pyramid ID= {p.pyramid_id} **\n")
@@ -770,6 +832,7 @@ class MasterController:
             f.write(f"  wave_frequency= {p.physics.wave_frequency}\n")
             f.write(f"  wave_phase= {p.physics.wave_phase}\n")
             f.write(f"  gravity= {p.physics.gravity}, bounce= {p.physics.bounce_factor}, mass= {p.physics.mass}\n")
+            f.write(f"  ground_collision_enabled= {p.physics.ground_collision_enabled}\n")
 
         print(f"[export_pyramid_file] => Created {path}")
 

--- a/pyramid.py
+++ b/pyramid.py
@@ -153,12 +153,17 @@ class PyramidPhysics:
         self.gravity = 9.8
         self.bounce_factor = 0.5
         self.mass = 1.0
+        self.ground_collision_enabled = True
 
         # wave config
         self.wave_axis_enable = {"x": False, "y": False, "z": False}
         self.wave_amplitude = {"x": 0.0, "y": 0.5, "z": 0.0}
         self.wave_frequency = {"x": 1.0, "y": 1.0, "z": 1.0}
         self.wave_phase = {"x": 0.0, "y": 0.0, "z": 0.0}
+        # Wave motion is a render-time offset.  Keeping it separate from the
+        # physical position prevents the sine value from accumulating every
+        # frame and sending an animated pyramid drifting out of the scene.
+        self.wave_offset = np.zeros(3, dtype=float)
 
     def update(self, dt, current_time):
         # 1) gravity
@@ -171,7 +176,7 @@ class PyramidPhysics:
         self.rotation += self.angular_velocity * dt
 
         # 4) bounce
-        if self.position[1]<0:
+        if self.ground_collision_enabled and self.position[1]<0:
             self.position[1] =0
             self.velocity[1] =-self.velocity[1]*self.bounce_factor
 
@@ -184,7 +189,7 @@ class PyramidPhysics:
                 ph = self.wave_phase[ax]
                 val = amp* math.sin(freq*current_time + ph)
                 wave_offset[idx] = val
-        self.position += wave_offset
+        self.wave_offset = wave_offset
 
     def apply_forward_thrust(self, force, dt):
         """
@@ -250,8 +255,9 @@ class Pyramid:
         Returns final (x,y,z) points after corner offsets & physics transform.
         """
         mod_path = self._apply_corner_offsets_to_local_path(self.local_path)
+        visual_position = self.physics.position + self.physics.wave_offset
         return self.transform_path(mod_path,
-                                   self.physics.position,
+                                   visual_position,
                                    self.physics.rotation)
 
     def set_corner_offset(self, corner_index, offset_vec):

--- a/pyramidGUI.py
+++ b/pyramidGUI.py
@@ -1,517 +1,997 @@
 #!/usr/bin/env python3
-"""
-gui.py - A more refined, playful GUI bridging a 1950s phone switchboard aesthetic
-         with a modern audio mixing console, controlling the MasterController.
+"""Rainbow Starburst desktop console and live OpenGL visualization.
 
-Enhancements:
-1) TWO knobs:
-   - Knob #1 => wave amplitude
-   - Knob #2 => globe subdivisions
-2) Particle mode toggles: OFF, LOW, MEDIUM, HEAVY
-3) Wave/Spin/Pulse toggles for animation modes
-4) Extra shapes for theming:
-   - "Speaker grill" rectangle
-   - "LED lamp" that glows if wave/spin is active
-5) Two windows:
-   - Switchboard console (UI)
-   - 3D Visualization
-6) Uses PyOpenGL calls for GL functions to avoid missing 'glMatrixMode' in pyglet.gl.
-
-Requires:
- - pyglet
- - PyOpenGL
- - numpy
- - mastercontroller.py and pyramid.py in the same folder
+The interface deliberately joins a tactile mid-century switchboard with a
+restrained modern mixing desk.  The companion viewport renders the selected
+pyramid formation, the animated rainbow trace, and interactive particle bursts.
 """
 
-import pyglet
-from pyglet.window import key, mouse
-from pyglet import shapes
+import colorsys
 import math
+import random
 import time
-import numpy as np
 
-# --- Importing PyOpenGL to fix the glMatrixMode issue ---
+import numpy as np
+import pyglet
+from pyglet import shapes
+from pyglet.window import key, mouse
+
+# PyOpenGL provides the compatibility-profile matrix and immediate-mode calls
+# used by the original renderer.
 from OpenGL.GL import *
 from OpenGL.GLU import *
 
 from mastercontroller import (
+    ANIMATION_PULSE,
+    ANIMATION_SPIN,
+    ANIMATION_WAVE_Y,
+    MAX_GLOBE_SUBDIVISIONS,
+    PARTICLE_HEAVY,
+    PARTICLE_LOW,
+    PARTICLE_MEDIUM,
+    PARTICLE_OFF,
     MasterController,
-    PARTICLE_OFF, PARTICLE_LOW, PARTICLE_MEDIUM, PARTICLE_HEAVY,
-    ANIMATION_WAVE_Y, ANIMATION_SPIN, ANIMATION_PULSE,
 )
 
-###############################################################################
-# GLOBAL / SHARED
-###############################################################################
+
+PALETTE = {
+    "ink": (13, 18, 23),
+    "panel": (27, 33, 38),
+    "panel_raised": (39, 46, 52),
+    "panel_hover": (51, 61, 68),
+    "line": (76, 85, 91),
+    "cream": (240, 229, 199),
+    "muted": (163, 167, 156),
+    "brass": (202, 164, 91),
+    "amber": (255, 180, 73),
+    "teal": (68, 202, 190),
+    "red": (235, 92, 86),
+    "blue": (94, 142, 236),
+}
+
+ARRANGEMENTS = ("Edge2Edge", "SpikeSphere", "Grid", "Star", "Globe")
+PARTICLE_MODES = (PARTICLE_OFF, PARTICLE_LOW, PARTICLE_MEDIUM, PARTICLE_HEAVY)
+ANIMATION_LABELS = ("WAVE", "SPIN", "PULSE", "NONE")
+ANIMATION_VALUES = {
+    "WAVE": ANIMATION_WAVE_Y,
+    "SPIN": ANIMATION_SPIN,
+    "PULSE": ANIMATION_PULSE,
+    "NONE": "",
+}
+
+
 ui_window = None
 visualization_window = None
-
 mc = MasterController()
 
-# KNOB #1 => wave amplitude
-knob_wave_value = 0.5
-# KNOB #2 => globe subdivisions
+knob_wave_value = 0.8
 knob_subdiv_value = 1.0
-
 turntable_angle = 0.0
 
-ui_batch         = pyglet.graphics.Batch()
-toggle_buttons   = []
+ui_batch = None
+toggle_buttons = []
 particle_buttons = []
-animation_buttons= []
-dial_knob_wave   = None
+animation_buttons = []
+dial_knob_wave = None
 dial_knob_subdiv = None
-turntable        = None
+turntable = None
+speaker_rect = None
+led_lamp = None
 
-# A "speaker grill" or decorative shape
-speaker_rect     = None
-# A "LED lamp" that glows if wave/spin/pulse is active
-led_lamp         = None
 
-###############################################################################
-# Switchboard Window
-###############################################################################
-class SwitchboardWindow(pyglet.window.Window):
-    def __init__(self, width, height, title):
-        super().__init__(width, height, title, resizable=False)
-        self.set_location(100,100)
-        
-        # Arrangement toggles
-        arrangement_labels = ["Edge2Edge", "SpikeSphere", "Grid", "Star", "Globe"]
-        x_start = 50
-        y_start = self.height - 70
-        spacing= 70
-        for i, lbl in enumerate(arrangement_labels):
-            btn = ToggleButton(
-                x=x_start+ i* spacing,
-                y=y_start,
-                width=60,
-                height=30,
-                text=lbl,
-                on_press=lambda l=lbl: self.on_arrangement_pressed(l),
-                batch=ui_batch
-            )
-            toggle_buttons.append(btn)
+def _rgba(rgb, alpha=255):
+    return (*rgb, alpha)
 
-        # Particle mode toggles
-        pmodes = [PARTICLE_OFF, PARTICLE_LOW, PARTICLE_MEDIUM, PARTICLE_HEAVY]
-        y2     = y_start - 50
-        for i, m in enumerate(pmodes):
-            btn = ToggleButton(
-                x=x_start+ i* spacing,
-                y=y2,
-                width=60,
-                height=30,
-                text=m,
-                on_press=lambda mode=m: self.on_particle_mode_pressed(mode),
-                batch=ui_batch
-            )
-            particle_buttons.append(btn)
 
-        # Animation toggles (Wave, Spin, Pulse, None)
-        anim_labels = ["WAVE", "SPIN", "PULSE", "NONE"]
-        y3          = y2 - 50
-        for i, lbl in enumerate(anim_labels):
-            btn = ToggleButton(
-                x=x_start+ i* spacing,
-                y=y3,
-                width=60,
-                height=30,
-                text=lbl,
-                on_press=lambda l=lbl: self.on_animation_pressed(l),
-                batch=ui_batch
-            )
-            animation_buttons.append(btn)
+def _rainbow_color(fraction, saturation=0.86, value=1.0):
+    """Return a smooth RGB rainbow color for a normalized fraction."""
+    hue = (fraction * 0.92) % 1.0
+    return colorsys.hsv_to_rgb(hue, saturation, value)
 
-        # A decorative "speaker grill" rectangle
-        global speaker_rect
-        speaker_rect = shapes.Rectangle(
-            x= 300,
-            y= 20,
-            width= 180,
-            height= 100,
-            color=(70,70,70),
-            batch= ui_batch
-        )
 
-        # "LED lamp" circle
-        global led_lamp
-        led_lamp= shapes.Circle(
-            x= speaker_rect.x+ speaker_rect.width//2,
-            y= speaker_rect.y+ speaker_rect.height+ 20,
-            radius= 10,
-            color=(0,0,0),
-            batch= ui_batch
-        )
-
-        # Knob #1 => wave amplitude
-        global dial_knob_wave
-        dial_knob_wave= Knob(
-            x=100, y=160, radius=30,
-            label="WaveAmp", 
-            batch= ui_batch,
-            on_drag=self.on_knob_wave_drag
-        )
-
-        # Knob #2 => globe subdivisions
-        global dial_knob_subdiv
-        dial_knob_subdiv= Knob(
-            x=220, y=160, radius=30,
-            label="GlobeSubdiv",
-            batch= ui_batch,
-            on_drag=self.on_knob_subdiv_drag
-        )
-
-        # Turntable => apex offset or anything
-        global turntable
-        turntable= Turntable(
-            x= 380, y= 200, radius=50,
-            label="Turntable",
-            on_spin=self.on_turntable_spin,
-            batch= ui_batch
-        )
-
-    def on_draw(self):
-        self.clear()
-        # We'll just do a quick background color
-        glClearColor(0.25, 0.25, 0.25, 1)
-        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-        ui_batch.draw()
-
-    # ARRANGEMENTS
-    def on_arrangement_pressed(self, label):
-        if label=="Edge2Edge":
-            mc.init_edge_to_edge_pyramids(count=5)
-        elif label=="SpikeSphere":
-            mc.init_spike_sphere_pyramids(count=10, sphere_radius=5.0)
-        elif label=="Grid":
-            mc.init_grid_pyramids(rows=3, cols=4, spacing_x=2.0, spacing_z=2.0)
-        elif label=="Star":
-            mc.init_star_formation(count=6, radius=5.0)
-        elif label=="Globe":
-            global knob_subdiv_value
-            subdiv = int(knob_subdiv_value)
-            if subdiv<0: subdiv=0
-            global turntable_angle
-            offset = 0.1 + (turntable_angle %360)/360.0
-            mc.init_globe_icosahedron(subdivisions=subdiv, apex_offset= offset, base_scale=1.0)
-
-    # PARTICLE MODE
-    def on_particle_mode_pressed(self, mode):
-        mc.set_particle_mode(mode)
-        print(f"[Particle Mode] => {mode}")
-
-    # ANIMATION
-    def on_animation_pressed(self, lbl):
-        if lbl=="WAVE":
-            mc.set_animation_mode(ANIMATION_WAVE_Y)
-            led_lamp.color= (0,255,0)   # green LED
-        elif lbl=="SPIN":
-            mc.set_animation_mode(ANIMATION_SPIN)
-            led_lamp.color= (255,0,0)   # red LED
-        elif lbl=="PULSE":
-            mc.set_animation_mode(ANIMATION_PULSE)
-            led_lamp.color= (0,0,255)   # blue LED
-        else:
-            mc.set_animation_mode("")
-            led_lamp.color= (0,0,0)     # off
-
-    # KNOBS
-    def on_knob_wave_drag(self, new_value):
-        """
-        wave amplitude real-time
-        """
-        global knob_wave_value
-        knob_wave_value = new_value
-        # apply to all pyramids if wave is enabled on y
-        for p in mc.pyramids:
-            if p.physics.wave_axis_enable["y"]:
-                p.physics.wave_amplitude["y"] = new_value
-        print(f"[KnobWave] => {knob_wave_value:.2f}")
-
-    def on_knob_subdiv_drag(self, new_value):
-        """
-        sets globe subdivisions => can re-init if we want real-time
-        """
-        global knob_subdiv_value
-        knob_subdiv_value= new_value
-        print(f"[KnobSubdiv] => {knob_subdiv_value:.2f}")
-        # optional auto-update:
-        # subdiv= int(knob_subdiv_value)
-        # offset= 0.1 + (turntable_angle%360)/360.0
-        # mc.init_globe_icosahedron(subdivisions=subdiv, apex_offset= offset, base_scale=1.0)
-
-    def on_turntable_spin(self, angle):
-        global turntable_angle
-        turntable_angle= angle
-        print(f"[Turntable spin] => angle= {turntable_angle:.1f}")
-
-###############################################################################
-# Visualization Window
-###############################################################################
-class VisualizationWindow(pyglet.window.Window):
-    def __init__(self, width, height, title):
-        super().__init__(width, height, title, resizable=True)
-        self.set_location(650,100)
-        self.start_time = time.time()
-        self.drawDist   = 0.0
-        self.drawing_forward= True
-        self.draw_speed = 2.0
-
-        pyglet.clock.schedule_interval(self.update, 1/60.0)
-
-    def update(self, dt):
-        current_time = time.time() - self.start_time
-        mc.update(dt, current_time)
-        if self.drawing_forward:
-            self.drawDist+= self.draw_speed* dt
-        else:
-            self.drawDist-= self.draw_speed* dt
-
-    def on_draw(self):
-        self.clear()
-        glEnable(GL_DEPTH_TEST)
-        glMatrixMode(GL_PROJECTION)
-        glLoadIdentity()
-        aspect= float(self.width)/ self.height
-        gluPerspective(60.0, aspect, 0.1, 100.0)
-
-        glMatrixMode(GL_MODELVIEW)
-        glLoadIdentity()
-        gluLookAt(0,3,12, 0,0,0, 0,1,0)
-
-        now= time.time()- self.start_time
-        glRotatef(now*15.0, 0,1,0)
-
-        # draw pyramids
-        self.draw_pyramids()
-        # bridging partial line
-        self.draw_rainbow_path()
-
-    def draw_pyramids(self):
-        for p in mc.pyramids:
-            tpath= p.get_transformed_path()
-            if len(tpath)<2:
-                continue
-            glLineWidth(1.0)
-            glColor3f(1,1,1)
-            glBegin(GL_LINE_STRIP)
-            for pt in tpath:
-                glVertex3f(pt[0], pt[1], pt[2])
-            glEnd()
-
-    def draw_rainbow_path(self):
-        points, total_len, dists= mc.build_global_path(close_loop=False, star_bridge=False)
-        if len(points)<2:
-            return
-        if self.drawDist> total_len:
-            self.drawDist= total_len
-            self.drawing_forward= False
-        elif self.drawDist<0:
-            self.drawDist= 0
-            self.drawing_forward= True
-
-        glLineWidth(2.0)
-        glBegin(GL_LINE_STRIP)
-        def get_color(frac):
-            hue= (frac*3.0)%1.0
-            i= int(hue*6)
-            f= hue*6- i
-            q= 1- f
-            if i==0: return (1, f, 0)
-            if i==1: return (q, 1, 0)
-            if i==2: return (0, 1, f)
-            if i==3: return (0, q, 1)
-            if i==4: return (f, 0, 1)
-            return (1, 0, q)
-
-        dist_clamped= self.drawDist
-        for i in range(len(points)-1):
-            seg_start= dists[i]
-            seg_end  = dists[i+1]
-            if seg_start> dist_clamped:
-                break
-            A= points[i]
-            B= points[i+1]
-            if seg_end< dist_clamped:
-                fracA= seg_start/ total_len
-                cA= get_color(fracA)
-                glColor3f(*cA)
-                glVertex3f(A[0],A[1],A[2])
-
-                fracB= seg_end/ total_len
-                cB= get_color(fracB)
-                glColor3f(*cB)
-                glVertex3f(B[0],B[1],B[2])
-            else:
-                alpha= (dist_clamped- seg_start)/(seg_end- seg_start)
-                midP= A+ alpha*(B- A)
-                fracA= seg_start/ total_len
-                cA= get_color(fracA)
-                glColor3f(*cA)
-                glVertex3f(A[0], A[1], A[2])
-
-                fracM= dist_clamped/ total_len
-                cM= get_color(fracM)
-                glColor3f(*cM)
-                glVertex3f(midP[0], midP[1], midP[2])
-                break
-        glEnd()
-
-###############################################################################
-# UI CLASSES
-###############################################################################
 class ToggleButton:
-    def __init__(self, x, y, width, height, text, on_press, batch):
+    """Tactile switch with active and hover states."""
+
+    def __init__(
+        self,
+        x,
+        y,
+        width,
+        height,
+        text,
+        on_press,
+        batch,
+        accent=None,
+    ):
         self.x = x
         self.y = y
         self.w = width
         self.h = height
-        self.on_press_callback= on_press
-        self.label= text
+        self.label = text
+        self.on_press_callback = on_press
+        self.accent = accent or PALETTE["amber"]
+        self.active = False
+        self.hovered = False
 
-        self.rect= shapes.Rectangle(x, y, width, height, color=(50,50,50), batch=batch)
-        self.txt= pyglet.text.Label(
-            text, 
-            x= x+ width//2,
-            y= y+ height//2,
-            anchor_x='center',
-            anchor_y='center',
-            font_size=8,
-            batch=batch
+        self.border = shapes.Rectangle(
+            x - 2, y - 2, width + 4, height + 4,
+            color=PALETTE["line"], batch=batch,
+        )
+        self.rect = shapes.Rectangle(
+            x, y, width, height,
+            color=PALETTE["panel_raised"], batch=batch,
+        )
+        self.signal = shapes.Rectangle(
+            x + 10, y + 6, max(4, width - 20), 3,
+            color=PALETTE["line"], batch=batch,
+        )
+        self.txt = pyglet.text.Label(
+            text,
+            x=x + width // 2,
+            y=y + height // 2 + 3,
+            anchor_x="center",
+            anchor_y="center",
+            font_name="Segoe UI",
+            font_size=10,
+            color=_rgba(PALETTE["cream"]),
+            batch=batch,
         )
 
     def hit_test(self, mx, my):
-        return (mx>=self.x and mx<= self.x+self.w and
-                my>=self.y and my<= self.y+self.h)
+        return self.x <= mx <= self.x + self.w and self.y <= my <= self.y + self.h
+
+    def set_active(self, active):
+        self.active = bool(active)
+        self._refresh()
+
+    def on_mouse_motion(self, mx, my):
+        hovered = self.hit_test(mx, my)
+        if hovered != self.hovered:
+            self.hovered = hovered
+            self._refresh()
 
     def on_mouse_press(self, mx, my, button, modifiers):
-        if button== mouse.LEFT:
-            if self.hit_test(mx,my):
-                self.on_press_callback()
+        if button == mouse.LEFT and self.hit_test(mx, my):
+            self.on_press_callback()
+            return True
+        return False
+
+    def _refresh(self):
+        if self.active:
+            self.border.color = self.accent
+            self.rect.color = self.accent
+            self.signal.color = PALETTE["cream"]
+            self.txt.color = _rgba(PALETTE["ink"])
+        else:
+            self.border.color = PALETTE["brass"] if self.hovered else PALETTE["line"]
+            self.rect.color = PALETTE["panel_hover"] if self.hovered else PALETTE["panel_raised"]
+            self.signal.color = self.accent if self.hovered else PALETTE["line"]
+            self.txt.color = _rgba(PALETTE["cream"])
+
 
 class Knob:
-    """
-    A simple rotary knob => range 0..10
-    """
-    def __init__(self, x, y, radius, label, batch, on_drag):
-        self.x= x
-        self.y= y
-        self.r= radius
-        self.value= 1.0
-        self.on_drag= on_drag
-        self.dragging= False
-        self.bg= shapes.Circle(x, y, radius, color=(120,120,120), batch=batch)
-        self.lbl= pyglet.text.Label(
-            label,
-            x=x,
-            y=y+ radius+ 15,
-            anchor_x='center',
-            anchor_y='center',
-            font_size=10,
-            batch=batch
+    """Rotary control with a bounded value and a readable live value."""
+
+    def __init__(
+        self,
+        x,
+        y,
+        radius,
+        label,
+        batch,
+        on_drag,
+        minimum=0.0,
+        maximum=1.0,
+        value=0.5,
+        step=None,
+        value_format="{:.1f}",
+    ):
+        self.x = x
+        self.y = y
+        self.r = radius
+        self.minimum = float(minimum)
+        self.maximum = float(maximum)
+        self.step = step
+        self.value_format = value_format
+        self.value = float(value)
+        self.on_drag = on_drag
+        self.dragging = False
+
+        self.halo = shapes.Circle(x, y, radius + 5, color=PALETTE["line"], batch=batch)
+        self.bg = shapes.Circle(x, y, radius, color=PALETTE["panel_raised"], batch=batch)
+        self.cap = shapes.Circle(x, y, max(7, radius - 13), color=PALETTE["panel"], batch=batch)
+        self.indicator = shapes.Line(
+            x, y, x, y + radius - 7,
+            thickness=4, color=PALETTE["amber"], batch=batch,
         )
+        self.lbl = pyglet.text.Label(
+            label.upper(),
+            x=x,
+            y=y + radius + 24,
+            anchor_x="center",
+            anchor_y="center",
+            font_name="Segoe UI",
+            font_size=9,
+            color=_rgba(PALETTE["muted"]),
+            batch=batch,
+        )
+        self.value_lbl = pyglet.text.Label(
+            "",
+            x=x,
+            y=y - radius - 19,
+            anchor_x="center",
+            anchor_y="center",
+            font_name="Consolas",
+            font_size=10,
+            color=_rgba(PALETTE["cream"]),
+            batch=batch,
+        )
+        self.set_value(value, notify=False)
 
     def hit_test(self, mx, my):
-        dx= mx- self.x
-        dy= my- self.y
-        dist= math.sqrt(dx*dx+ dy*dy)
-        return dist<= self.r
+        return math.hypot(mx - self.x, my - self.y) <= self.r + 5
 
     def on_mouse_press(self, mx, my, button, modifiers):
-        if button== mouse.LEFT:
-            if self.hit_test(mx,my):
-                self.dragging= True
+        if button == mouse.LEFT and self.hit_test(mx, my):
+            self.dragging = True
+            self._set_from_pointer(mx, my)
+            return True
+        return False
 
     def on_mouse_drag(self, mx, my, dx, dy, buttons, modifiers):
         if self.dragging and (buttons & mouse.LEFT):
-            angle= math.degrees(math.atan2(my- self.y, mx- self.x))
-            if angle<0:
-                angle+=360
-            new_val= (angle/360.0)*10.0
-            self.value= new_val
-            self.on_drag(new_val)
+            self._set_from_pointer(mx, my)
 
     def on_mouse_release(self, mx, my, button, modifiers):
-        if self.dragging and button== mouse.LEFT:
-            self.dragging= False
+        if self.dragging and button == mouse.LEFT:
+            self.dragging = False
+
+    def set_value(self, value, notify=True):
+        value = max(self.minimum, min(self.maximum, float(value)))
+        if self.step:
+            value = round(value / self.step) * self.step
+        self.value = value
+        fraction = 0.0 if self.maximum == self.minimum else (
+            (value - self.minimum) / (self.maximum - self.minimum)
+        )
+        angle = math.radians(225.0 + fraction * 270.0)
+        length = self.r - 8
+        self.indicator.x2 = self.x + math.cos(angle) * length
+        self.indicator.y2 = self.y + math.sin(angle) * length
+        self.value_lbl.text = self.value_format.format(value)
+        if notify:
+            self.on_drag(value)
+
+    def _set_from_pointer(self, mx, my):
+        angle = math.degrees(math.atan2(my - self.y, mx - self.x)) % 360.0
+        relative = (angle - 225.0) % 360.0
+        if relative > 270.0:
+            # The unused 90-degree arc is the knob's hard stop.  Snap to the
+            # nearest endpoint so dragging through it remains predictable.
+            relative = 0.0 if relative > 315.0 else 270.0
+        fraction = relative / 270.0
+        self.set_value(self.minimum + fraction * (self.maximum - self.minimum))
+
 
 class Turntable:
-    """
-    Spinning disc => angle => on_spin(angle)
-    """
+    """Large tactile disc controlling the globe apex offset."""
+
     def __init__(self, x, y, radius, label, on_spin, batch):
-        self.x= x
-        self.y= y
-        self.r= radius
-        self.angle= 0
-        self.dragging= False
-        self.on_spin= on_spin
-        self.bg= shapes.Circle(x, y, radius, color=(80,80,200), batch=batch)
-        self.lbl= pyglet.text.Label(
-            label,
-            x=x, y=y- radius-15,
-            anchor_x='center', anchor_y='center',
+        self.x = x
+        self.y = y
+        self.r = radius
+        self.angle = 0.0
+        self.dragging = False
+        self.on_spin = on_spin
+
+        self.outer = shapes.Circle(x, y, radius + 6, color=PALETTE["brass"], batch=batch)
+        self.bg = shapes.Circle(x, y, radius, color=(28, 37, 47), batch=batch)
+        self.groove_a = shapes.Circle(x, y, radius - 10, color=(40, 50, 61), batch=batch)
+        self.groove_b = shapes.Circle(x, y, radius - 17, color=(23, 30, 38), batch=batch)
+        self.hub = shapes.Circle(x, y, 8, color=PALETTE["cream"], batch=batch)
+        self.indicator = shapes.Line(
+            x, y, x + radius - 12, y,
+            thickness=3, color=PALETTE["amber"], batch=batch,
+        )
+        self.lbl = pyglet.text.Label(
+            label.upper(),
+            x=x,
+            y=y + radius + 25,
+            anchor_x="center",
+            anchor_y="center",
+            font_name="Segoe UI",
+            font_size=9,
+            color=_rgba(PALETTE["muted"]),
+            batch=batch,
+        )
+        self.value_lbl = pyglet.text.Label(
+            "000°",
+            x=x,
+            y=y - radius - 19,
+            anchor_x="center",
+            anchor_y="center",
+            font_name="Consolas",
             font_size=10,
-            batch=batch
+            color=_rgba(PALETTE["cream"]),
+            batch=batch,
         )
 
     def hit_test(self, mx, my):
-        dx= mx- self.x
-        dy= my- self.y
-        dist= math.sqrt(dx*dx+ dy*dy)
-        return dist<= self.r
+        return math.hypot(mx - self.x, my - self.y) <= self.r + 6
 
     def on_mouse_press(self, mx, my, button, modifiers):
-        if button== mouse.LEFT:
-            if self.hit_test(mx,my):
-                self.dragging= True
+        if button == mouse.LEFT and self.hit_test(mx, my):
+            self.dragging = True
+            self._set_from_pointer(mx, my)
+            return True
+        return False
 
     def on_mouse_drag(self, mx, my, dx, dy, buttons, modifiers):
         if self.dragging and (buttons & mouse.LEFT):
-            angle= math.degrees(math.atan2(my- self.y, mx- self.x))
-            if angle<0:
-                angle+=360
-            self.angle= angle
-            self.on_spin(angle)
+            self._set_from_pointer(mx, my)
 
     def on_mouse_release(self, mx, my, button, modifiers):
-        if self.dragging and button== mouse.LEFT:
-            self.dragging= False
+        if self.dragging and button == mouse.LEFT:
+            self.dragging = False
 
-###############################################################################
+    def _set_from_pointer(self, mx, my):
+        self.angle = math.degrees(math.atan2(my - self.y, mx - self.x)) % 360.0
+        radians = math.radians(self.angle)
+        length = self.r - 12
+        self.indicator.x2 = self.x + math.cos(radians) * length
+        self.indicator.y2 = self.y + math.sin(radians) * length
+        self.value_lbl.text = f"{int(round(self.angle)) % 360:03d}°"
+        self.on_spin(self.angle)
+
+
+class SwitchboardWindow(pyglet.window.Window):
+    """Primary working surface for arrangements, signals, and motion."""
+
+    def __init__(self, width=760, height=620, title="Rainbow Starburst — Switchboard"):
+        super().__init__(width, height, title, resizable=False, vsync=True)
+
+        global ui_batch, speaker_rect, led_lamp
+        global dial_knob_wave, dial_knob_subdiv, turntable
+
+        ui_batch = pyglet.graphics.Batch()
+        toggle_buttons.clear()
+        particle_buttons.clear()
+        animation_buttons.clear()
+
+        self.active_arrangement = "Star"
+        self.active_particle = PARTICLE_OFF
+        self.active_animation = "WAVE"
+        self.status_expires = 0.0
+        self.static_labels = []
+        self.decoration_shapes = []
+
+        self.background = shapes.Rectangle(
+            0, 0, width, height, color=PALETTE["ink"], batch=ui_batch,
+        )
+        self.faceplate = shapes.Rectangle(
+            20, 18, width - 40, height - 36,
+            color=PALETTE["panel"], batch=ui_batch,
+        )
+        self.header_rule = shapes.Rectangle(
+            40, height - 98, width - 80, 2,
+            color=PALETTE["brass"], batch=ui_batch,
+        )
+
+        self._label(
+            "RAINBOW / STARBURST", 40, height - 48,
+            22, PALETTE["cream"], anchor_y="center",
+        )
+        self._label(
+            "PYRAMID SIGNAL CONSOLE  •  RS–01", 42, height - 76,
+            9, PALETTE["muted"], anchor_y="center",
+        )
+        self.live_dot = shapes.Circle(
+            width - 138, height - 57, 6,
+            color=PALETTE["teal"], batch=ui_batch,
+        )
+        self._label(
+            "SYSTEM LIVE", width - 122, height - 57,
+            9, PALETTE["teal"], anchor_y="center",
+        )
+
+        self._section_label("01  FORMATION ROUTING", 40, height - 132)
+        button_width = 120
+        gap = 14
+        x_start = 40
+        y_arrangements = height - 195
+        for index, label in enumerate(ARRANGEMENTS):
+            button = ToggleButton(
+                x=x_start + index * (button_width + gap),
+                y=y_arrangements,
+                width=button_width,
+                height=42,
+                text=label.upper(),
+                on_press=lambda value=label: self.on_arrangement_pressed(value),
+                batch=ui_batch,
+                accent=PALETTE["amber"],
+            )
+            toggle_buttons.append(button)
+
+        self._section_label("02  PARTICLE GAIN", 40, height - 240)
+        self._section_label("03  MOTION PROGRAM", 392, height - 240)
+        compact_width = 72
+        compact_gap = 10
+        y_modes = height - 302
+        for index, mode in enumerate(PARTICLE_MODES):
+            button = ToggleButton(
+                x=40 + index * (compact_width + compact_gap),
+                y=y_modes,
+                width=compact_width,
+                height=40,
+                text=mode,
+                on_press=lambda value=mode: self.on_particle_mode_pressed(value),
+                batch=ui_batch,
+                accent=PALETTE["teal"],
+            )
+            particle_buttons.append(button)
+
+        for index, label in enumerate(ANIMATION_LABELS):
+            button = ToggleButton(
+                x=392 + index * (compact_width + compact_gap),
+                y=y_modes,
+                width=compact_width,
+                height=40,
+                text=label,
+                on_press=lambda value=label: self.on_animation_pressed(value),
+                batch=ui_batch,
+                accent=PALETTE["red"] if label == "SPIN" else PALETTE["blue"],
+            )
+            animation_buttons.append(button)
+
+        self.deck_rule = shapes.Rectangle(
+            40, 244, width - 80, 1, color=PALETTE["line"], batch=ui_batch,
+        )
+        self._section_label("04  CONTROL DECK", 40, 226)
+
+        dial_knob_wave = Knob(
+            x=105,
+            y=128,
+            radius=42,
+            label="Wave amplitude",
+            batch=ui_batch,
+            on_drag=self.on_knob_wave_drag,
+            minimum=0.0,
+            maximum=2.0,
+            value=knob_wave_value,
+            step=0.05,
+            value_format="{:.2f}",
+        )
+        dial_knob_subdiv = Knob(
+            x=246,
+            y=128,
+            radius=42,
+            label="Globe detail",
+            batch=ui_batch,
+            on_drag=self.on_knob_subdiv_drag,
+            minimum=0.0,
+            maximum=float(MAX_GLOBE_SUBDIVISIONS),
+            value=knob_subdiv_value,
+            step=1.0,
+            value_format="{:.0f}",
+        )
+        turntable = Turntable(
+            x=408,
+            y=126,
+            radius=54,
+            label="Apex offset",
+            on_spin=self.on_turntable_spin,
+            batch=ui_batch,
+        )
+
+        speaker_rect = shapes.Rectangle(
+            514, 69, 198, 112, color=(20, 25, 29), batch=ui_batch,
+        )
+        self.speaker_border = shapes.Rectangle(
+            510, 65, 206, 120, color=PALETTE["line"], batch=ui_batch,
+        )
+        # Re-create the inner rectangle after the border so it stays visually inset.
+        speaker_rect = shapes.Rectangle(
+            514, 69, 198, 112, color=(20, 25, 29), batch=ui_batch,
+        )
+        for index in range(10):
+            self.decoration_shapes.append(shapes.Rectangle(
+                526,
+                81 + index * 9,
+                174,
+                2,
+                color=(54, 62, 66),
+                batch=ui_batch,
+            ))
+        self._label(
+            "SIGNAL MONITOR", 613, 198,
+            9, PALETTE["muted"], anchor_x="center", anchor_y="center",
+        )
+        self.led_halo = shapes.Circle(
+            613, 211, 10, color=(54, 62, 66), batch=ui_batch,
+        )
+        led_lamp = shapes.Circle(
+            613, 211, 5, color=PALETTE["teal"], batch=ui_batch,
+        )
+
+        self.status_label = pyglet.text.Label(
+            "",
+            x=40,
+            y=36,
+            anchor_x="left",
+            anchor_y="center",
+            font_name="Consolas",
+            font_size=9,
+            color=_rgba(PALETTE["muted"]),
+            batch=ui_batch,
+        )
+        self.help_label = pyglet.text.Label(
+            "1–5 FORMATIONS  •  CLICK VIEWPORT FOR BURSTS",
+            x=width - 40,
+            y=36,
+            anchor_x="right",
+            anchor_y="center",
+            font_name="Segoe UI",
+            font_size=8,
+            color=_rgba(PALETTE["muted"]),
+            batch=ui_batch,
+        )
+
+        self._sync_active_states()
+        self.set_status("STAR FORMATION ROUTED  •  WAVE PROGRAM ACTIVE")
+
+    def _label(
+        self,
+        text,
+        x,
+        y,
+        font_size,
+        color,
+        anchor_x="left",
+        anchor_y="baseline",
+    ):
+        label = pyglet.text.Label(
+            text,
+            x=x,
+            y=y,
+            anchor_x=anchor_x,
+            anchor_y=anchor_y,
+            font_name="Segoe UI",
+            font_size=font_size,
+            color=_rgba(color),
+            batch=ui_batch,
+        )
+        self.static_labels.append(label)
+        return label
+
+    def _section_label(self, text, x, y):
+        return self._label(text, x, y, 9, PALETTE["brass"])
+
+    def _sync_active_states(self):
+        for button, value in zip(toggle_buttons, ARRANGEMENTS):
+            button.set_active(value == self.active_arrangement)
+        for button, value in zip(particle_buttons, PARTICLE_MODES):
+            button.set_active(value == self.active_particle)
+        for button, value in zip(animation_buttons, ANIMATION_LABELS):
+            button.set_active(value == self.active_animation)
+
+    def set_status(self, message, duration=4.0):
+        self.status_label.text = message
+        self.status_expires = time.time() + duration
+
+    def on_draw(self):
+        glClearColor(*(channel / 255.0 for channel in PALETTE["ink"]), 1.0)
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+        ui_batch.draw()
+
+    def on_mouse_motion(self, x, y, dx, dy):
+        for button in toggle_buttons + particle_buttons + animation_buttons:
+            button.on_mouse_motion(x, y)
+
+    def on_mouse_press(self, x, y, button, modifiers):
+        for control in toggle_buttons + particle_buttons + animation_buttons:
+            if control.on_mouse_press(x, y, button, modifiers):
+                return
+        if dial_knob_wave.on_mouse_press(x, y, button, modifiers):
+            return
+        if dial_knob_subdiv.on_mouse_press(x, y, button, modifiers):
+            return
+        turntable.on_mouse_press(x, y, button, modifiers)
+
+    def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
+        dial_knob_wave.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
+        dial_knob_subdiv.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
+        turntable.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
+
+    def on_mouse_release(self, x, y, button, modifiers):
+        dial_knob_wave.on_mouse_release(x, y, button, modifiers)
+        dial_knob_subdiv.on_mouse_release(x, y, button, modifiers)
+        turntable.on_mouse_release(x, y, button, modifiers)
+
+    def on_key_press(self, symbol, modifiers):
+        arrangement_keys = {
+            key._1: "Edge2Edge",
+            key._2: "SpikeSphere",
+            key._3: "Grid",
+            key._4: "Star",
+            key._5: "Globe",
+        }
+        if symbol in arrangement_keys:
+            self.on_arrangement_pressed(arrangement_keys[symbol])
+        elif symbol == key.ESCAPE:
+            pyglet.app.exit()
+
+    def on_close(self):
+        pyglet.app.exit()
+
+    def on_arrangement_pressed(self, label):
+        if label == "Edge2Edge":
+            mc.init_edge_to_edge_pyramids(count=7)
+        elif label == "SpikeSphere":
+            mc.init_spike_sphere_pyramids(count=24, sphere_radius=4.0)
+        elif label == "Grid":
+            mc.init_grid_pyramids(rows=4, cols=5, spacing_x=1.8, spacing_z=1.8)
+        elif label == "Star":
+            mc.init_star_formation(subdivisions=1, core_radius=3.0, spike_height=2.4)
+        elif label == "Globe":
+            subdivisions = int(round(knob_subdiv_value))
+            offset = 0.18 + (turntable_angle % 360.0) / 360.0 * 0.7
+            mc.init_globe_icosahedron(
+                subdivisions=subdivisions,
+                apex_offset=offset,
+                base_scale=4.0,
+            )
+
+        self.active_arrangement = label
+        mc.set_animation_mode(ANIMATION_VALUES[self.active_animation])
+        self._apply_wave_value()
+        self._sync_active_states()
+        self.set_status(f"{label.upper()} ROUTED  •  {len(mc.pyramids)} PYRAMIDS")
+        if visualization_window is not None:
+            visualization_window.set_scene(label)
+
+    def on_particle_mode_pressed(self, mode):
+        self.active_particle = mode
+        mc.set_particle_mode(mode)
+        self._sync_active_states()
+        message = "PARTICLE GAIN MUTED" if mode == PARTICLE_OFF else (
+            f"PARTICLE GAIN {mode}  •  CLICK THE 3D VIEWPORT TO BURST"
+        )
+        self.set_status(message)
+
+    def on_animation_pressed(self, label):
+        self.active_animation = label
+        mc.set_animation_mode(ANIMATION_VALUES[label])
+        self._apply_wave_value()
+        self._sync_active_states()
+
+        lamp_colors = {
+            "WAVE": PALETTE["teal"],
+            "SPIN": PALETTE["red"],
+            "PULSE": PALETTE["blue"],
+            "NONE": (38, 44, 47),
+        }
+        led_lamp.color = lamp_colors[label]
+        self.led_halo.color = lamp_colors[label] if label != "NONE" else PALETTE["line"]
+        self.set_status(f"MOTION PROGRAM {label}")
+
+    def _apply_wave_value(self):
+        if self.active_animation not in ("WAVE", "PULSE"):
+            return
+        multiplier = 1.65 if self.active_animation == "PULSE" else 1.0
+        for pyramid in mc.pyramids:
+            if pyramid.physics.wave_axis_enable["y"]:
+                pyramid.physics.wave_amplitude["y"] = knob_wave_value * multiplier
+
+    def on_knob_wave_drag(self, new_value):
+        global knob_wave_value
+        knob_wave_value = float(new_value)
+        self._apply_wave_value()
+        self.set_status(f"WAVE AMPLITUDE  {knob_wave_value:.2f}", duration=2.0)
+
+    def on_knob_subdiv_drag(self, new_value):
+        global knob_subdiv_value
+        knob_subdiv_value = float(int(round(new_value)))
+        faces = 20 * (4 ** int(knob_subdiv_value))
+        self.set_status(
+            f"GLOBE DETAIL  {int(knob_subdiv_value)}  •  {faces} FACES ON NEXT ROUTE",
+            duration=2.0,
+        )
+
+    def on_turntable_spin(self, angle):
+        global turntable_angle
+        turntable_angle = float(angle)
+        offset = 0.18 + (turntable_angle % 360.0) / 360.0 * 0.7
+        self.set_status(f"GLOBE APEX OFFSET  {offset:.2f}", duration=2.0)
+
+
+class VisualizationWindow(pyglet.window.Window):
+    """Live 3D stage for the selected formation and its signal trace."""
+
+    def __init__(self, width=900, height=650, title="Rainbow Starburst — 3D Signal"):
+        super().__init__(width, height, title, resizable=True, vsync=True)
+        self.set_minimum_size(560, 420)
+        self.start_time = time.time()
+        self.draw_dist = 0.0
+        self.drawing_forward = True
+        self.draw_speed = 8.0
+        self.camera_distance = 14.0
+        self.scene_name = "Star"
+        self.paused = False
+        self.cursor_world = np.zeros(3, dtype=float)
+        self.cursor_visible = False
+
+        rng = random.Random(86)
+        self.stars = [
+            (
+                rng.uniform(-14.0, 14.0),
+                rng.uniform(-6.0, 11.0),
+                rng.uniform(-12.0, -2.0),
+                rng.uniform(0.25, 0.8),
+            )
+            for _ in range(120)
+        ]
+
+        self.hud_batch = pyglet.graphics.Batch()
+        self.hud_brand = pyglet.text.Label(
+            "RAINBOW / STARBURST",
+            x=26,
+            y=height - 30,
+            anchor_x="left",
+            anchor_y="top",
+            font_name="Segoe UI",
+            font_size=13,
+            color=_rgba(PALETTE["cream"]),
+            batch=self.hud_batch,
+        )
+        self.hud_scene = pyglet.text.Label(
+            "",
+            x=26,
+            y=height - 55,
+            anchor_x="left",
+            anchor_y="top",
+            font_name="Consolas",
+            font_size=9,
+            color=_rgba(PALETTE["teal"]),
+            batch=self.hud_batch,
+        )
+        self.hud_help = pyglet.text.Label(
+            "CLICK: PARTICLE BURST   •   SCROLL: CAMERA   •   SPACE: PAUSE",
+            x=26,
+            y=22,
+            anchor_x="left",
+            anchor_y="bottom",
+            font_name="Segoe UI",
+            font_size=8,
+            color=_rgba(PALETTE["muted"]),
+            batch=self.hud_batch,
+        )
+        self._update_hud()
+        pyglet.clock.schedule_interval(self.update, 1.0 / 60.0)
+
+    def set_scene(self, name):
+        self.scene_name = name
+        self.draw_dist = 0.0
+        self.drawing_forward = True
+        self._update_hud()
+
+    def _update_hud(self):
+        paused = "  •  PAUSED" if self.paused else ""
+        self.hud_scene.text = (
+            f"{self.scene_name.upper()}  •  {len(mc.pyramids)} PYRAMIDS"
+            f"  •  PARTICLES {mc.current_particle_mode}{paused}"
+        )
+
+    def update(self, dt):
+        if self.paused:
+            return
+        dt = min(dt, 0.05)
+        current_time = time.time() - self.start_time
+        mc.update(dt, current_time)
+        self.draw_dist += self.draw_speed * dt * (1.0 if self.drawing_forward else -1.0)
+        self._update_hud()
+
+    def on_draw(self):
+        glViewport(0, 0, self.width, self.height)
+        glClearColor(0.012, 0.018, 0.028, 1.0)
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+        glEnable(GL_DEPTH_TEST)
+        glEnable(GL_BLEND)
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+        glDisable(GL_CULL_FACE)
+
+        glMatrixMode(GL_PROJECTION)
+        glLoadIdentity()
+        aspect = float(self.width) / max(1.0, float(self.height))
+        gluPerspective(58.0, aspect, 0.1, 100.0)
+
+        glMatrixMode(GL_MODELVIEW)
+        glLoadIdentity()
+        gluLookAt(0.0, 8.5, self.camera_distance, 0.0, 0.4, 0.0, 0.0, 1.0, 0.0)
+
+        now = time.time() - self.start_time
+        glRotatef(now * 8.0, 0.0, 1.0, 0.0)
+
+        self.draw_starfield()
+        self.draw_floor_grid()
+        self.draw_pyramids()
+        self.draw_rainbow_path()
+        self.draw_particles()
+        if self.cursor_visible:
+            self.draw_cursor_marker()
+
+        glDisable(GL_DEPTH_TEST)
+        self.hud_batch.draw()
+
+    def draw_starfield(self):
+        glPointSize(2.0)
+        glBegin(GL_POINTS)
+        for x, y, z, brightness in self.stars:
+            glColor4f(brightness, brightness * 0.94, brightness * 0.78, brightness)
+            glVertex3f(x, y, z)
+        glEnd()
+
+    def draw_floor_grid(self):
+        glLineWidth(1.0)
+        glBegin(GL_LINES)
+        for value in range(-8, 9):
+            alpha = 0.22 if value == 0 else 0.08
+            glColor4f(0.32, 0.62, 0.64, alpha)
+            glVertex3f(value, -0.02, -8)
+            glVertex3f(value, -0.02, 8)
+            glVertex3f(-8, -0.02, value)
+            glVertex3f(8, -0.02, value)
+        glEnd()
+
+    def draw_pyramids(self):
+        glLineWidth(1.5)
+        glColor4f(1.0, 1.0, 1.0, 0.68)
+        for pyramid in mc.pyramids:
+            path = pyramid.get_transformed_path()
+            if len(path) < 2:
+                continue
+            glBegin(GL_LINE_STRIP)
+            for point in path:
+                glVertex3f(float(point[0]), float(point[1]), float(point[2]))
+            glEnd()
+
+    def draw_rainbow_path(self):
+        points, total_length, distances = mc.build_global_path(
+            close_loop=False,
+            star_bridge=False,
+        )
+        if len(points) < 2 or total_length <= 1e-9:
+            return
+
+        if self.draw_dist > total_length:
+            self.draw_dist = total_length
+            self.drawing_forward = False
+        elif self.draw_dist < 0.0:
+            self.draw_dist = 0.0
+            self.drawing_forward = True
+
+        glLineWidth(3.0)
+        glBegin(GL_LINE_STRIP)
+        for index in range(len(points) - 1):
+            segment_start = distances[index]
+            segment_end = distances[index + 1]
+            if segment_start > self.draw_dist:
+                break
+            point_a = points[index]
+            point_b = points[index + 1]
+
+            fraction_a = segment_start / total_length
+            glColor3f(*_rainbow_color(fraction_a))
+            glVertex3f(float(point_a[0]), float(point_a[1]), float(point_a[2]))
+
+            if segment_end <= self.draw_dist:
+                fraction_b = segment_end / total_length
+                glColor3f(*_rainbow_color(fraction_b))
+                glVertex3f(float(point_b[0]), float(point_b[1]), float(point_b[2]))
+                continue
+
+            segment_length = segment_end - segment_start
+            if segment_length > 1e-9:
+                alpha = (self.draw_dist - segment_start) / segment_length
+                midpoint = point_a + alpha * (point_b - point_a)
+                glColor3f(*_rainbow_color(self.draw_dist / total_length))
+                glVertex3f(float(midpoint[0]), float(midpoint[1]), float(midpoint[2]))
+            break
+        glEnd()
+
+    def draw_particles(self):
+        if not mc.particles:
+            return
+        glPointSize(4.0)
+        glBegin(GL_POINTS)
+        for particle in mc.particles:
+            alpha = max(0.0, min(1.0, particle.life / 2.0))
+            glColor4f(*particle.color, alpha)
+            glVertex3f(*particle.position)
+        glEnd()
+
+    def draw_cursor_marker(self):
+        x, y, z = self.cursor_world
+        glLineWidth(2.0)
+        glColor4f(1.0, 0.72, 0.3, 0.7)
+        glBegin(GL_LINES)
+        glVertex3f(x - 0.25, y, z)
+        glVertex3f(x + 0.25, y, z)
+        glVertex3f(x, y, z - 0.25)
+        glVertex3f(x, y, z + 0.25)
+        glEnd()
+
+    def _screen_to_world(self, x, y):
+        normalized_x = (x / max(1.0, self.width) - 0.5) * 13.0
+        normalized_z = (y / max(1.0, self.height) - 0.5) * 10.0
+        return np.array([normalized_x, 0.35, -normalized_z], dtype=float)
+
+    def on_mouse_motion(self, x, y, dx, dy):
+        self.cursor_world = self._screen_to_world(x, y)
+        self.cursor_visible = True
+
+    def on_mouse_press(self, x, y, button, modifiers):
+        if button == mouse.LEFT:
+            self.cursor_world = self._screen_to_world(x, y)
+            self.cursor_visible = True
+            mc.handle_collision(self.cursor_world)
+            self._update_hud()
+
+    def on_mouse_scroll(self, x, y, scroll_x, scroll_y):
+        self.camera_distance = max(7.0, min(24.0, self.camera_distance - scroll_y * 0.8))
+
+    def on_key_press(self, symbol, modifiers):
+        if symbol == key.SPACE:
+            self.paused = not self.paused
+            self._update_hud()
+        elif symbol == key.R:
+            self.camera_distance = 14.0
+            self.draw_dist = 0.0
+            self.drawing_forward = True
+        elif symbol == key.ESCAPE:
+            pyglet.app.exit()
+
+    def on_resize(self, width, height):
+        super().on_resize(width, height)
+        self.hud_brand.y = height - 30
+        self.hud_scene.y = height - 55
+
+    def on_close(self):
+        pyglet.clock.unschedule(self.update)
+        pyglet.app.exit()
+
+
 def run_gui():
+    """Launch the switchboard and its companion visualization window."""
     global ui_window, visualization_window
 
-    ui_window= SwitchboardWindow(width=600, height=500, title="Switchboard Console")
-    visualization_window= VisualizationWindow(width=800, height=600, title="3D Visualization")
+    # A scene switch is also a programming operation: when it returns, the
+    # exported files must already match the active formation exactly.
+    mc.configure_export(enabled=True, async_mode=False)
+    mc.init_star_formation(subdivisions=1, core_radius=3.0, spike_height=2.4)
+    mc.set_animation_mode(ANIMATION_WAVE_Y)
+    for pyramid in mc.pyramids:
+        pyramid.physics.wave_amplitude["y"] = knob_wave_value
 
-    @ui_window.event
-    def on_mouse_press(x,y, button, modifiers):
-        for t in toggle_buttons:
-            t.on_mouse_press(x,y,button,modifiers)
-        for t in particle_buttons:
-            t.on_mouse_press(x,y,button,modifiers)
-        for t in animation_buttons:
-            t.on_mouse_press(x,y,button,modifiers)
-        dial_knob_wave.on_mouse_press(x,y,button,modifiers)
-        dial_knob_subdiv.on_mouse_press(x,y,button,modifiers)
-        turntable.on_mouse_press(x,y,button,modifiers)
+    ui_window = SwitchboardWindow()
+    visualization_window = VisualizationWindow()
 
-    @ui_window.event
-    def on_mouse_drag(x,y, dx, dy, buttons, modifiers):
-        dial_knob_wave.on_mouse_drag(x,y,dx,dy,buttons,modifiers)
-        dial_knob_subdiv.on_mouse_drag(x,y,dx,dy,buttons,modifiers)
-        turntable.on_mouse_drag(x,y,dx,dy,buttons,modifiers)
-
-    @ui_window.event
-    def on_mouse_release(x,y, button, modifiers):
-        dial_knob_wave.on_mouse_release(x,y,button,modifiers)
-        dial_knob_subdiv.on_mouse_release(x,y,button,modifiers)
-        turntable.on_mouse_release(x,y,button,modifiers)
+    screen = ui_window.screen
+    gap = 20
+    total_width = ui_window.width + visualization_window.width + gap
+    if screen.width >= total_width + 60:
+        left = max(30, (screen.width - total_width) // 2)
+        bottom = max(40, (screen.height - max(ui_window.height, visualization_window.height)) // 2)
+        ui_window.set_location(left, bottom + 15)
+        visualization_window.set_location(left + ui_window.width + gap, bottom)
+    else:
+        ui_window.set_location(30, max(30, screen.height - ui_window.height - 60))
+        visualization_window.set_location(
+            max(60, screen.width - visualization_window.width - 40),
+            40,
+        )
 
     pyglet.app.run()
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     run_gui()

--- a/pyramidGUI.py
+++ b/pyramidGUI.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
-"""Rainbow Starburst desktop console and live OpenGL visualization.
+"""Rainbow Starburst switchboard and live audio-reactive OpenGL stage."""
 
-The interface deliberately joins a tactile mid-century switchboard with a
-restrained modern mixing desk.  The companion viewport renders the selected
-pyramid formation, the animated rainbow trace, and interactive particle bursts.
-"""
+from __future__ import annotations
 
 import colorsys
 import math
@@ -15,12 +12,39 @@ import numpy as np
 import pyglet
 from pyglet import shapes
 from pyglet.window import key, mouse
+from OpenGL.GL import (
+    GL_BLEND,
+    GL_COLOR_BUFFER_BIT,
+    GL_CULL_FACE,
+    GL_DEPTH_BUFFER_BIT,
+    GL_DEPTH_TEST,
+    GL_LINES,
+    GL_LINE_STRIP,
+    GL_MODELVIEW,
+    GL_ONE_MINUS_SRC_ALPHA,
+    GL_POINTS,
+    GL_PROJECTION,
+    GL_SRC_ALPHA,
+    glBegin,
+    glBlendFunc,
+    glClear,
+    glClearColor,
+    glColor4f,
+    glDisable,
+    glEnable,
+    glEnd,
+    glLineWidth,
+    glLoadIdentity,
+    glMatrixMode,
+    glPointSize,
+    glRotatef,
+    glVertex3f,
+    glViewport,
+)
+from OpenGL.GLU import gluLookAt, gluPerspective
 
-# PyOpenGL provides the compatibility-profile matrix and immediate-mode calls
-# used by the original renderer.
-from OpenGL.GL import *
-from OpenGL.GLU import *
-
+from animations import AnimationDirector, PROGRAM_NAMES, apply_render_state
+from audio import AudioEngine, AudioSourceMode
 from mastercontroller import (
     ANIMATION_PULSE,
     ANIMATION_SPIN,
@@ -32,16 +56,17 @@ from mastercontroller import (
     PARTICLE_OFF,
     MasterController,
 )
+from settings import load_settings, save_settings
 
 
 PALETTE = {
-    "ink": (13, 18, 23),
-    "panel": (27, 33, 38),
-    "panel_raised": (39, 46, 52),
+    "ink": (11, 16, 21),
+    "panel": (25, 31, 36),
+    "panel_raised": (38, 45, 51),
     "panel_hover": (51, 61, 68),
-    "line": (76, 85, 91),
+    "line": (75, 85, 91),
     "cream": (240, 229, 199),
-    "muted": (163, 167, 156),
+    "muted": (157, 163, 155),
     "brass": (202, 164, 91),
     "amber": (255, 180, 73),
     "teal": (68, 202, 190),
@@ -50,6 +75,7 @@ PALETTE = {
 }
 
 ARRANGEMENTS = ("Edge2Edge", "SpikeSphere", "Grid", "Star", "Globe")
+SOURCE_LABELS = ("OFF", "SYSTEM", "MIC", "BOTH", "DEMO")
 PARTICLE_MODES = (PARTICLE_OFF, PARTICLE_LOW, PARTICLE_MEDIUM, PARTICLE_HEAVY)
 ANIMATION_LABELS = ("WAVE", "SPIN", "PULSE", "NONE")
 ANIMATION_VALUES = {
@@ -59,24 +85,16 @@ ANIMATION_VALUES = {
     "NONE": "",
 }
 
+mc = MasterController()
+audio_engine = AudioEngine()
+director = AnimationDirector()
+preferences = load_settings()
 
 ui_window = None
 visualization_window = None
-mc = MasterController()
-
 knob_wave_value = 0.8
-knob_subdiv_value = 1.0
+knob_detail_value = 1.0
 turntable_angle = 0.0
-
-ui_batch = None
-toggle_buttons = []
-particle_buttons = []
-animation_buttons = []
-dial_knob_wave = None
-dial_knob_subdiv = None
-turntable = None
-speaker_rect = None
-led_lamp = None
 
 
 def _rgba(rgb, alpha=255):
@@ -84,75 +102,58 @@ def _rgba(rgb, alpha=255):
 
 
 def _rainbow_color(fraction, saturation=0.86, value=1.0):
-    """Return a smooth RGB rainbow color for a normalized fraction."""
-    hue = (fraction * 0.92) % 1.0
-    return colorsys.hsv_to_rgb(hue, saturation, value)
+    return colorsys.hsv_to_rgb(float(fraction) % 1.0, saturation, value)
+
+
+def _short_name(value, limit=30):
+    text = str(value)
+    return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
 class ToggleButton:
-    """Tactile switch with active and hover states."""
+    """A compact, keyboard-like switch with one clear active state."""
 
-    def __init__(
-        self,
-        x,
-        y,
-        width,
-        height,
-        text,
-        on_press,
-        batch,
-        accent=None,
-    ):
-        self.x = x
-        self.y = y
-        self.w = width
-        self.h = height
-        self.label = text
-        self.on_press_callback = on_press
+    def __init__(self, x, y, width, height, text, on_press, batch, accent=None):
+        self.x, self.y, self.width, self.height = x, y, width, height
+        self.on_press = on_press
         self.accent = accent or PALETTE["amber"]
         self.active = False
         self.hovered = False
-
-        self.border = shapes.Rectangle(
-            x - 2, y - 2, width + 4, height + 4,
-            color=PALETTE["line"], batch=batch,
-        )
-        self.rect = shapes.Rectangle(
-            x, y, width, height,
-            color=PALETTE["panel_raised"], batch=batch,
-        )
-        self.signal = shapes.Rectangle(
-            x + 10, y + 6, max(4, width - 20), 3,
-            color=PALETTE["line"], batch=batch,
-        )
+        self.border = shapes.Rectangle(x - 1, y - 1, width + 2, height + 2, color=PALETTE["line"], batch=batch)
+        self.rect = shapes.Rectangle(x, y, width, height, color=PALETTE["panel_raised"], batch=batch)
+        self.signal = shapes.Rectangle(x, y, 3, height, color=PALETTE["line"], batch=batch)
         self.txt = pyglet.text.Label(
             text,
-            x=x + width // 2,
-            y=y + height // 2 + 3,
+            x=x + width / 2,
+            y=y + height / 2,
             anchor_x="center",
             anchor_y="center",
             font_name="Segoe UI",
-            font_size=10,
+            font_size=8,
             color=_rgba(PALETTE["cream"]),
             batch=batch,
         )
 
-    def hit_test(self, mx, my):
-        return self.x <= mx <= self.x + self.w and self.y <= my <= self.y + self.h
+    def hit_test(self, x, y):
+        return self.x <= x <= self.x + self.width and self.y <= y <= self.y + self.height
 
     def set_active(self, active):
         self.active = bool(active)
         self._refresh()
 
-    def on_mouse_motion(self, mx, my):
-        hovered = self.hit_test(mx, my)
+    def set_text(self, value):
+        self.txt.text = str(value)
+
+    def on_mouse_motion(self, x, y):
+        hovered = self.hit_test(x, y)
         if hovered != self.hovered:
             self.hovered = hovered
             self._refresh()
 
-    def on_mouse_press(self, mx, my, button, modifiers):
-        if button == mouse.LEFT and self.hit_test(mx, my):
-            self.on_press_callback()
+    def on_mouse_press(self, x, y, button, modifiers):
+        del modifiers
+        if button == mouse.LEFT and self.hit_test(x, y):
+            self.on_press()
             return True
         return False
 
@@ -170,80 +171,47 @@ class ToggleButton:
 
 
 class Knob:
-    """Rotary control with a bounded value and a readable live value."""
+    """Bounded rotary parameter with a live numeric readout."""
 
-    def __init__(
-        self,
-        x,
-        y,
-        radius,
-        label,
-        batch,
-        on_drag,
-        minimum=0.0,
-        maximum=1.0,
-        value=0.5,
-        step=None,
-        value_format="{:.1f}",
-    ):
-        self.x = x
-        self.y = y
-        self.r = radius
-        self.minimum = float(minimum)
-        self.maximum = float(maximum)
-        self.step = step
-        self.value_format = value_format
+    def __init__(self, x, y, radius, label, batch, on_drag, minimum, maximum, value, step, value_format):
+        self.x, self.y, self.r = x, y, radius
+        self.minimum, self.maximum = float(minimum), float(maximum)
+        self.on_drag, self.step, self.value_format = on_drag, step, value_format
         self.value = float(value)
-        self.on_drag = on_drag
         self.dragging = False
-
-        self.halo = shapes.Circle(x, y, radius + 5, color=PALETTE["line"], batch=batch)
+        self.halo = shapes.Circle(x, y, radius + 4, color=PALETTE["line"], batch=batch)
         self.bg = shapes.Circle(x, y, radius, color=PALETTE["panel_raised"], batch=batch)
-        self.cap = shapes.Circle(x, y, max(7, radius - 13), color=PALETTE["panel"], batch=batch)
-        self.indicator = shapes.Line(
-            x, y, x, y + radius - 7,
-            thickness=4, color=PALETTE["amber"], batch=batch,
+        self.cap = shapes.Circle(x, y, max(7, radius - 12), color=PALETTE["panel"], batch=batch)
+        self.indicator = shapes.Line(x, y, x, y + radius - 7, thickness=3, color=PALETTE["amber"], batch=batch)
+        self.label = pyglet.text.Label(
+            label.upper(), x=x, y=y + radius + 18, anchor_x="center", anchor_y="center",
+            font_name="Segoe UI", font_size=8, color=_rgba(PALETTE["muted"]), batch=batch,
         )
-        self.lbl = pyglet.text.Label(
-            label.upper(),
-            x=x,
-            y=y + radius + 24,
-            anchor_x="center",
-            anchor_y="center",
-            font_name="Segoe UI",
-            font_size=9,
-            color=_rgba(PALETTE["muted"]),
-            batch=batch,
-        )
-        self.value_lbl = pyglet.text.Label(
-            "",
-            x=x,
-            y=y - radius - 19,
-            anchor_x="center",
-            anchor_y="center",
-            font_name="Consolas",
-            font_size=10,
-            color=_rgba(PALETTE["cream"]),
-            batch=batch,
+        self.value_label = pyglet.text.Label(
+            "", x=x, y=y - radius - 16, anchor_x="center", anchor_y="center",
+            font_name="Consolas", font_size=9, color=_rgba(PALETTE["cream"]), batch=batch,
         )
         self.set_value(value, notify=False)
 
-    def hit_test(self, mx, my):
-        return math.hypot(mx - self.x, my - self.y) <= self.r + 5
+    def hit_test(self, x, y):
+        return math.hypot(x - self.x, y - self.y) <= self.r + 5
 
-    def on_mouse_press(self, mx, my, button, modifiers):
-        if button == mouse.LEFT and self.hit_test(mx, my):
+    def on_mouse_press(self, x, y, button, modifiers):
+        del modifiers
+        if button == mouse.LEFT and self.hit_test(x, y):
             self.dragging = True
-            self._set_from_pointer(mx, my)
+            self._set_from_pointer(x, y)
             return True
         return False
 
-    def on_mouse_drag(self, mx, my, dx, dy, buttons, modifiers):
-        if self.dragging and (buttons & mouse.LEFT):
-            self._set_from_pointer(mx, my)
+    def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
+        del dx, dy, modifiers
+        if self.dragging and buttons & mouse.LEFT:
+            self._set_from_pointer(x, y)
 
-    def on_mouse_release(self, mx, my, button, modifiers):
-        if self.dragging and button == mouse.LEFT:
+    def on_mouse_release(self, x, y, button, modifiers):
+        del x, y, modifiers
+        if button == mouse.LEFT:
             self.dragging = False
 
     def set_value(self, value, notify=True):
@@ -251,379 +219,241 @@ class Knob:
         if self.step:
             value = round(value / self.step) * self.step
         self.value = value
-        fraction = 0.0 if self.maximum == self.minimum else (
-            (value - self.minimum) / (self.maximum - self.minimum)
-        )
+        fraction = (value - self.minimum) / max(1e-9, self.maximum - self.minimum)
         angle = math.radians(225.0 + fraction * 270.0)
-        length = self.r - 8
+        length = self.r - 7
         self.indicator.x2 = self.x + math.cos(angle) * length
         self.indicator.y2 = self.y + math.sin(angle) * length
-        self.value_lbl.text = self.value_format.format(value)
+        self.value_label.text = self.value_format.format(value)
         if notify:
             self.on_drag(value)
 
-    def _set_from_pointer(self, mx, my):
-        angle = math.degrees(math.atan2(my - self.y, mx - self.x)) % 360.0
+    def _set_from_pointer(self, x, y):
+        angle = math.degrees(math.atan2(y - self.y, x - self.x)) % 360.0
         relative = (angle - 225.0) % 360.0
         if relative > 270.0:
-            # The unused 90-degree arc is the knob's hard stop.  Snap to the
-            # nearest endpoint so dragging through it remains predictable.
             relative = 0.0 if relative > 315.0 else 270.0
-        fraction = relative / 270.0
-        self.set_value(self.minimum + fraction * (self.maximum - self.minimum))
+        self.set_value(self.minimum + relative / 270.0 * (self.maximum - self.minimum))
 
 
 class Turntable:
-    """Large tactile disc controlling the globe apex offset."""
-
-    def __init__(self, x, y, radius, label, on_spin, batch):
-        self.x = x
-        self.y = y
-        self.r = radius
-        self.angle = 0.0
-        self.dragging = False
+    def __init__(self, x, y, radius, label, batch, on_spin):
+        self.x, self.y, self.r = x, y, radius
         self.on_spin = on_spin
-
-        self.outer = shapes.Circle(x, y, radius + 6, color=PALETTE["brass"], batch=batch)
+        self.dragging = False
+        self.angle = 0.0
+        self.outer = shapes.Circle(x, y, radius + 5, color=PALETTE["brass"], batch=batch)
         self.bg = shapes.Circle(x, y, radius, color=(28, 37, 47), batch=batch)
-        self.groove_a = shapes.Circle(x, y, radius - 10, color=(40, 50, 61), batch=batch)
-        self.groove_b = shapes.Circle(x, y, radius - 17, color=(23, 30, 38), batch=batch)
-        self.hub = shapes.Circle(x, y, 8, color=PALETTE["cream"], batch=batch)
-        self.indicator = shapes.Line(
-            x, y, x + radius - 12, y,
-            thickness=3, color=PALETTE["amber"], batch=batch,
+        self.groove = shapes.Circle(x, y, radius - 10, color=(19, 26, 32), batch=batch)
+        self.hub = shapes.Circle(x, y, 7, color=PALETTE["cream"], batch=batch)
+        self.indicator = shapes.Line(x, y, x + radius - 10, y, thickness=3, color=PALETTE["amber"], batch=batch)
+        self.label = pyglet.text.Label(
+            label.upper(), x=x, y=y + radius + 18, anchor_x="center", anchor_y="center",
+            font_name="Segoe UI", font_size=8, color=_rgba(PALETTE["muted"]), batch=batch,
         )
-        self.lbl = pyglet.text.Label(
-            label.upper(),
-            x=x,
-            y=y + radius + 25,
-            anchor_x="center",
-            anchor_y="center",
-            font_name="Segoe UI",
-            font_size=9,
-            color=_rgba(PALETTE["muted"]),
-            batch=batch,
-        )
-        self.value_lbl = pyglet.text.Label(
-            "000°",
-            x=x,
-            y=y - radius - 19,
-            anchor_x="center",
-            anchor_y="center",
-            font_name="Consolas",
-            font_size=10,
-            color=_rgba(PALETTE["cream"]),
-            batch=batch,
+        self.value_label = pyglet.text.Label(
+            "000°", x=x, y=y - radius - 16, anchor_x="center", anchor_y="center",
+            font_name="Consolas", font_size=9, color=_rgba(PALETTE["cream"]), batch=batch,
         )
 
-    def hit_test(self, mx, my):
-        return math.hypot(mx - self.x, my - self.y) <= self.r + 6
+    def hit_test(self, x, y):
+        return math.hypot(x - self.x, y - self.y) <= self.r + 5
 
-    def on_mouse_press(self, mx, my, button, modifiers):
-        if button == mouse.LEFT and self.hit_test(mx, my):
+    def on_mouse_press(self, x, y, button, modifiers):
+        del modifiers
+        if button == mouse.LEFT and self.hit_test(x, y):
             self.dragging = True
-            self._set_from_pointer(mx, my)
+            self._set(x, y)
             return True
         return False
 
-    def on_mouse_drag(self, mx, my, dx, dy, buttons, modifiers):
-        if self.dragging and (buttons & mouse.LEFT):
-            self._set_from_pointer(mx, my)
+    def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
+        del dx, dy, modifiers
+        if self.dragging and buttons & mouse.LEFT:
+            self._set(x, y)
 
-    def on_mouse_release(self, mx, my, button, modifiers):
-        if self.dragging and button == mouse.LEFT:
+    def on_mouse_release(self, x, y, button, modifiers):
+        del x, y, modifiers
+        if button == mouse.LEFT:
             self.dragging = False
 
-    def _set_from_pointer(self, mx, my):
-        self.angle = math.degrees(math.atan2(my - self.y, mx - self.x)) % 360.0
+    def _set(self, x, y):
+        self.angle = math.degrees(math.atan2(y - self.y, x - self.x)) % 360.0
         radians = math.radians(self.angle)
-        length = self.r - 12
+        length = self.r - 10
         self.indicator.x2 = self.x + math.cos(radians) * length
         self.indicator.y2 = self.y + math.sin(radians) * length
-        self.value_lbl.text = f"{int(round(self.angle)) % 360:03d}°"
+        self.value_label.text = f"{int(round(self.angle)) % 360:03d}°"
         self.on_spin(self.angle)
 
 
 class SwitchboardWindow(pyglet.window.Window):
-    """Primary working surface for arrangements, signals, and motion."""
+    """A restrained studio console around one dominant live visual canvas."""
 
-    def __init__(self, width=760, height=620, title="Rainbow Starburst — Switchboard"):
+    def __init__(self, width=840, height=760, title="Rainbow Starburst — Switchboard"):
         super().__init__(width, height, title, resizable=False, vsync=True)
-
-        global ui_batch, speaker_rect, led_lamp
-        global dial_knob_wave, dial_knob_subdiv, turntable
-
-        ui_batch = pyglet.graphics.Batch()
-        toggle_buttons.clear()
-        particle_buttons.clear()
-        animation_buttons.clear()
-
+        self.batch = pyglet.graphics.Batch()
+        self.labels = []
+        self.controls = []
+        self.formation_buttons = []
+        self.source_buttons = []
+        self.program_buttons = []
+        self.motion_buttons = []
+        self.particle_buttons = []
         self.active_arrangement = "Star"
-        self.active_particle = PARTICLE_OFF
+        self.active_source = "OFF"  # Never auto-open a saved microphone.
+        self.active_program = preferences.audio_program if preferences.audio_program in PROGRAM_NAMES else "CINEMA"
         self.active_animation = "WAVE"
-        self.status_expires = 0.0
-        self.static_labels = []
-        self.decoration_shapes = []
+        self.active_particle = PARTICLE_OFF
+        self.system_devices, self.microphone_devices = audio_engine.devices()
 
-        self.background = shapes.Rectangle(
-            0, 0, width, height, color=PALETTE["ink"], batch=ui_batch,
-        )
-        self.faceplate = shapes.Rectangle(
-            20, 18, width - 40, height - 36,
-            color=PALETTE["panel"], batch=ui_batch,
-        )
-        self.header_rule = shapes.Rectangle(
-            40, height - 98, width - 80, 2,
-            color=PALETTE["brass"], batch=ui_batch,
-        )
+        shapes.Rectangle(0, 0, width, height, color=PALETTE["ink"], batch=self.batch)
+        shapes.Rectangle(20, 18, width - 40, height - 36, color=PALETTE["panel"], batch=self.batch)
+        shapes.Rectangle(40, 668, width - 80, 2, color=PALETTE["brass"], batch=self.batch)
+        self._label("RAINBOW / STARBURST", 40, 716, 22, PALETTE["cream"], anchor_y="center")
+        self._label("PYRAMID SIGNAL CONSOLE  •  RS–02", 42, 690, 9, PALETTE["muted"], anchor_y="center")
+        self.live_dot = shapes.Circle(width - 142, 704, 6, color=PALETTE["line"], batch=self.batch)
+        self.live_label = self._label("AUDIO OFF", width - 126, 704, 9, PALETTE["muted"], anchor_y="center")
 
-        self._label(
-            "RAINBOW / STARBURST", 40, height - 48,
-            22, PALETTE["cream"], anchor_y="center",
-        )
-        self._label(
-            "PYRAMID SIGNAL CONSOLE  •  RS–01", 42, height - 76,
-            9, PALETTE["muted"], anchor_y="center",
-        )
-        self.live_dot = shapes.Circle(
-            width - 138, height - 57, 6,
-            color=PALETTE["teal"], batch=ui_batch,
-        )
-        self._label(
-            "SYSTEM LIVE", width - 122, height - 57,
-            9, PALETTE["teal"], anchor_y="center",
-        )
+        self._section("01  FORMATION ROUTING", 40, 644)
+        self._button_row(ARRANGEMENTS, 40, 590, 144, 8, self.formation_buttons, self.on_arrangement, PALETTE["amber"])
+        self._section("02  LOCAL AUDIO SOURCE", 40, 560)
+        self._button_row(SOURCE_LABELS, 40, 506, 144, 8, self.source_buttons, self.on_source, PALETTE["teal"])
+        self._section("03  AUDIO-REACTIVE PROGRAM", 40, 476)
+        self._button_row(PROGRAM_NAMES, 40, 422, 100, 8, self.program_buttons, self.on_program, PALETTE["blue"])
 
-        self._section_label("01  FORMATION ROUTING", 40, height - 132)
-        button_width = 120
-        gap = 14
-        x_start = 40
-        y_arrangements = height - 195
-        for index, label in enumerate(ARRANGEMENTS):
-            button = ToggleButton(
-                x=x_start + index * (button_width + gap),
-                y=y_arrangements,
-                width=button_width,
-                height=42,
-                text=label.upper(),
-                on_press=lambda value=label: self.on_arrangement_pressed(value),
-                batch=ui_batch,
-                accent=PALETTE["amber"],
-            )
-            toggle_buttons.append(button)
+        self._section("04  MANUAL MOTION", 40, 391)
+        self._button_row(ANIMATION_LABELS, 40, 338, 80, 8, self.motion_buttons, self.on_manual_motion, PALETTE["amber"])
+        self._section("05  PARTICLE LIMIT", 446, 391)
+        self._button_row(PARTICLE_MODES, 446, 338, 74, 8, self.particle_buttons, self.on_particle, PALETTE["teal"])
 
-        self._section_label("02  PARTICLE GAIN", 40, height - 240)
-        self._section_label("03  MOTION PROGRAM", 392, height - 240)
-        compact_width = 72
-        compact_gap = 10
-        y_modes = height - 302
-        for index, mode in enumerate(PARTICLE_MODES):
-            button = ToggleButton(
-                x=40 + index * (compact_width + compact_gap),
-                y=y_modes,
-                width=compact_width,
-                height=40,
-                text=mode,
-                on_press=lambda value=mode: self.on_particle_mode_pressed(value),
-                batch=ui_batch,
-                accent=PALETTE["teal"],
-            )
-            particle_buttons.append(button)
+        shapes.Rectangle(40, 306, width - 80, 1, color=PALETTE["line"], batch=self.batch)
+        self._section("06  RESPONSE + DEVICE STATUS", 40, 284)
+        self.sensitivity_knob = Knob(
+            94, 191, 36, "Sensitivity", self.batch, self.on_sensitivity,
+            0.5, 2.0, preferences.sensitivity, 0.05, "{:.2f}",
+        )
+        self.reactivity_knob = Knob(
+            214, 191, 36, "Reactivity", self.batch, self.on_reactivity,
+            0.55, 1.6, preferences.reactivity, 0.05, "{:.2f}",
+        )
+        self.detail_knob = Knob(
+            334, 191, 36, "Globe detail", self.batch, self.on_detail,
+            0, MAX_GLOBE_SUBDIVISIONS, knob_detail_value, 1, "{:.0f}",
+        )
+        self.apex_turntable = Turntable(460, 188, 45, "Apex offset", self.batch, self.on_apex)
+        self.controls.extend((self.sensitivity_knob, self.reactivity_knob, self.detail_knob, self.apex_turntable))
 
-        for index, label in enumerate(ANIMATION_LABELS):
-            button = ToggleButton(
-                x=392 + index * (compact_width + compact_gap),
-                y=y_modes,
-                width=compact_width,
-                height=40,
-                text=label,
-                on_press=lambda value=label: self.on_animation_pressed(value),
-                batch=ui_batch,
-                accent=PALETTE["red"] if label == "SPIN" else PALETTE["blue"],
-            )
-            animation_buttons.append(button)
+        self.system_name = self._label("SYSTEM  —", 548, 250, 8, PALETTE["muted"])
+        self.system_meter_bg = shapes.Rectangle(548, 230, 244, 5, color=(48, 56, 61), batch=self.batch)
+        self.system_meter = shapes.Rectangle(548, 230, 0, 5, color=PALETTE["teal"], batch=self.batch)
+        self.mic_name = self._label("MIC     —", 548, 208, 8, PALETTE["muted"])
+        self.mic_meter_bg = shapes.Rectangle(548, 188, 244, 5, color=(48, 56, 61), batch=self.batch)
+        self.mic_meter = shapes.Rectangle(548, 188, 0, 5, color=PALETTE["amber"], batch=self.batch)
+        self.telemetry = self._label("0.0 MS  •  0 DROPPED", 548, 164, 8, PALETTE["muted"])
+        self.privacy = self._label("LIVE ANALYSIS — NOT RECORDING", 548, 143, 8, PALETTE["brass"])
+        self.system_device_button = ToggleButton(548, 94, 118, 32, "NEXT SYSTEM", self.cycle_system_device, self.batch, PALETTE["teal"])
+        self.mic_device_button = ToggleButton(674, 94, 118, 32, "NEXT MIC", self.cycle_microphone_device, self.batch, PALETTE["amber"])
+        self.reduced_button = ToggleButton(548, 54, 244, 30, "REDUCED MOTION", self.toggle_reduced_motion, self.batch, PALETTE["blue"])
+        self.controls.extend((self.system_device_button, self.mic_device_button, self.reduced_button))
 
-        self.deck_rule = shapes.Rectangle(
-            40, 244, width - 80, 1, color=PALETTE["line"], batch=ui_batch,
+        self.status_label = self._label("", 40, 34, 8, PALETTE["muted"], anchor_y="center")
+        self.help_label = self._label(
+            "1–5 FORMATIONS  •  SPACE PAUSES VIEW", width - 40, 34, 8, PALETTE["muted"],
+            anchor_x="right", anchor_y="center",
         )
-        self._section_label("04  CONTROL DECK", 40, 226)
+        self._sync_buttons()
+        self._update_device_names()
+        self.reduced_button.set_active(bool(preferences.reduced_motion))
+        director.sensitivity = float(preferences.sensitivity)
+        director.reactivity = float(preferences.reactivity)
+        director.reduced_motion = bool(preferences.reduced_motion)
+        self.set_status("STAR ROUTED  •  MANUAL WAVE ACTIVE")
+        pyglet.clock.schedule_interval(self.update_audio_status, 0.1)
 
-        dial_knob_wave = Knob(
-            x=105,
-            y=128,
-            radius=42,
-            label="Wave amplitude",
-            batch=ui_batch,
-            on_drag=self.on_knob_wave_drag,
-            minimum=0.0,
-            maximum=2.0,
-            value=knob_wave_value,
-            step=0.05,
-            value_format="{:.2f}",
-        )
-        dial_knob_subdiv = Knob(
-            x=246,
-            y=128,
-            radius=42,
-            label="Globe detail",
-            batch=ui_batch,
-            on_drag=self.on_knob_subdiv_drag,
-            minimum=0.0,
-            maximum=float(MAX_GLOBE_SUBDIVISIONS),
-            value=knob_subdiv_value,
-            step=1.0,
-            value_format="{:.0f}",
-        )
-        turntable = Turntable(
-            x=408,
-            y=126,
-            radius=54,
-            label="Apex offset",
-            on_spin=self.on_turntable_spin,
-            batch=ui_batch,
-        )
-
-        speaker_rect = shapes.Rectangle(
-            514, 69, 198, 112, color=(20, 25, 29), batch=ui_batch,
-        )
-        self.speaker_border = shapes.Rectangle(
-            510, 65, 206, 120, color=PALETTE["line"], batch=ui_batch,
-        )
-        # Re-create the inner rectangle after the border so it stays visually inset.
-        speaker_rect = shapes.Rectangle(
-            514, 69, 198, 112, color=(20, 25, 29), batch=ui_batch,
-        )
-        for index in range(10):
-            self.decoration_shapes.append(shapes.Rectangle(
-                526,
-                81 + index * 9,
-                174,
-                2,
-                color=(54, 62, 66),
-                batch=ui_batch,
-            ))
-        self._label(
-            "SIGNAL MONITOR", 613, 198,
-            9, PALETTE["muted"], anchor_x="center", anchor_y="center",
-        )
-        self.led_halo = shapes.Circle(
-            613, 211, 10, color=(54, 62, 66), batch=ui_batch,
-        )
-        led_lamp = shapes.Circle(
-            613, 211, 5, color=PALETTE["teal"], batch=ui_batch,
-        )
-
-        self.status_label = pyglet.text.Label(
-            "",
-            x=40,
-            y=36,
-            anchor_x="left",
-            anchor_y="center",
-            font_name="Consolas",
-            font_size=9,
-            color=_rgba(PALETTE["muted"]),
-            batch=ui_batch,
-        )
-        self.help_label = pyglet.text.Label(
-            "1–5 FORMATIONS  •  CLICK VIEWPORT FOR BURSTS",
-            x=width - 40,
-            y=36,
-            anchor_x="right",
-            anchor_y="center",
-            font_name="Segoe UI",
-            font_size=8,
-            color=_rgba(PALETTE["muted"]),
-            batch=ui_batch,
-        )
-
-        self._sync_active_states()
-        self.set_status("STAR FORMATION ROUTED  •  WAVE PROGRAM ACTIVE")
-
-    def _label(
-        self,
-        text,
-        x,
-        y,
-        font_size,
-        color,
-        anchor_x="left",
-        anchor_y="baseline",
-    ):
+    def _label(self, text, x, y, size, color, anchor_x="left", anchor_y="baseline"):
         label = pyglet.text.Label(
-            text,
-            x=x,
-            y=y,
-            anchor_x=anchor_x,
-            anchor_y=anchor_y,
-            font_name="Segoe UI",
-            font_size=font_size,
-            color=_rgba(color),
-            batch=ui_batch,
+            text, x=x, y=y, anchor_x=anchor_x, anchor_y=anchor_y,
+            font_name="Segoe UI", font_size=size, color=_rgba(color), batch=self.batch,
         )
-        self.static_labels.append(label)
+        self.labels.append(label)
         return label
 
-    def _section_label(self, text, x, y):
+    def _section(self, text, x, y):
         return self._label(text, x, y, 9, PALETTE["brass"])
 
-    def _sync_active_states(self):
-        for button, value in zip(toggle_buttons, ARRANGEMENTS):
-            button.set_active(value == self.active_arrangement)
-        for button, value in zip(particle_buttons, PARTICLE_MODES):
-            button.set_active(value == self.active_particle)
-        for button, value in zip(animation_buttons, ANIMATION_LABELS):
-            button.set_active(value == self.active_animation)
+    def _button_row(self, values, x, y, width, gap, collection, callback, accent):
+        for index, value in enumerate(values):
+            button = ToggleButton(
+                x + index * (width + gap), y, width, 38, str(value),
+                lambda selected=value: callback(selected), self.batch, accent,
+            )
+            collection.append(button)
+            self.controls.append(button)
 
-    def set_status(self, message, duration=4.0):
-        self.status_label.text = message
-        self.status_expires = time.time() + duration
+    def _sync_buttons(self):
+        for button, value in zip(self.formation_buttons, ARRANGEMENTS):
+            button.set_active(value == self.active_arrangement)
+        for button, value in zip(self.source_buttons, SOURCE_LABELS):
+            button.set_active(value == self.active_source)
+        for button, value in zip(self.program_buttons, PROGRAM_NAMES):
+            button.set_active(value == self.active_program)
+        for button, value in zip(self.motion_buttons, ANIMATION_LABELS):
+            button.set_active(value == self.active_animation)
+        for button, value in zip(self.particle_buttons, PARTICLE_MODES):
+            button.set_active(value == self.active_particle)
+
+    def _save(self):
+        preferences.audio_source = self.active_source
+        preferences.audio_program = self.active_program
+        preferences.system_device_id = audio_engine.system_device_id
+        preferences.microphone_device_id = audio_engine.microphone_device_id
+        preferences.sensitivity = director.sensitivity
+        preferences.reactivity = director.reactivity
+        preferences.reduced_motion = director.reduced_motion
+        try:
+            save_settings(preferences)
+        except OSError:
+            pass
+
+    def set_status(self, message):
+        self.status_label.text = str(message)
 
     def on_draw(self):
         glClearColor(*(channel / 255.0 for channel in PALETTE["ink"]), 1.0)
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-        ui_batch.draw()
+        self.batch.draw()
 
     def on_mouse_motion(self, x, y, dx, dy):
-        for button in toggle_buttons + particle_buttons + animation_buttons:
-            button.on_mouse_motion(x, y)
+        del dx, dy
+        for control in self.controls:
+            if isinstance(control, ToggleButton):
+                control.on_mouse_motion(x, y)
 
     def on_mouse_press(self, x, y, button, modifiers):
-        for control in toggle_buttons + particle_buttons + animation_buttons:
+        for control in self.controls:
             if control.on_mouse_press(x, y, button, modifiers):
                 return
-        if dial_knob_wave.on_mouse_press(x, y, button, modifiers):
-            return
-        if dial_knob_subdiv.on_mouse_press(x, y, button, modifiers):
-            return
-        turntable.on_mouse_press(x, y, button, modifiers)
 
     def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
-        dial_knob_wave.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
-        dial_knob_subdiv.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
-        turntable.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
+        for control in self.controls:
+            if isinstance(control, (Knob, Turntable)):
+                control.on_mouse_drag(x, y, dx, dy, buttons, modifiers)
 
     def on_mouse_release(self, x, y, button, modifiers):
-        dial_knob_wave.on_mouse_release(x, y, button, modifiers)
-        dial_knob_subdiv.on_mouse_release(x, y, button, modifiers)
-        turntable.on_mouse_release(x, y, button, modifiers)
+        for control in self.controls:
+            if isinstance(control, (Knob, Turntable)):
+                control.on_mouse_release(x, y, button, modifiers)
 
     def on_key_press(self, symbol, modifiers):
-        arrangement_keys = {
-            key._1: "Edge2Edge",
-            key._2: "SpikeSphere",
-            key._3: "Grid",
-            key._4: "Star",
-            key._5: "Globe",
-        }
-        if symbol in arrangement_keys:
-            self.on_arrangement_pressed(arrangement_keys[symbol])
+        del modifiers
+        formations = {key._1: "Edge2Edge", key._2: "SpikeSphere", key._3: "Grid", key._4: "Star", key._5: "Globe"}
+        if symbol in formations:
+            self.on_arrangement(formations[symbol])
         elif symbol == key.ESCAPE:
-            pyglet.app.exit()
+            self._shutdown()
 
-    def on_close(self):
-        pyglet.app.exit()
-
-    def on_arrangement_pressed(self, label):
+    def on_arrangement(self, label):
         if label == "Edge2Edge":
             mc.init_edge_to_edge_pyramids(count=7)
         elif label == "SpikeSphere":
@@ -633,48 +463,103 @@ class SwitchboardWindow(pyglet.window.Window):
         elif label == "Star":
             mc.init_star_formation(subdivisions=1, core_radius=3.0, spike_height=2.4)
         elif label == "Globe":
-            subdivisions = int(round(knob_subdiv_value))
+            detail = int(round(self.detail_knob.value))
             offset = 0.18 + (turntable_angle % 360.0) / 360.0 * 0.7
-            mc.init_globe_icosahedron(
-                subdivisions=subdivisions,
-                apex_offset=offset,
-                base_scale=4.0,
-            )
-
+            mc.init_globe_icosahedron(subdivisions=detail, apex_offset=offset, base_scale=4.0)
         self.active_arrangement = label
-        mc.set_animation_mode(ANIMATION_VALUES[self.active_animation])
-        self._apply_wave_value()
-        self._sync_active_states()
+        if self.active_source == "OFF":
+            mc.set_animation_mode(ANIMATION_VALUES[self.active_animation])
+            self._apply_wave()
+        else:
+            mc.set_animation_mode("")
+        director.set_formation(mc.pyramids)
+        self._sync_buttons()
         self.set_status(f"{label.upper()} ROUTED  •  {len(mc.pyramids)} PYRAMIDS")
-        if visualization_window is not None:
+        if visualization_window:
             visualization_window.set_scene(label)
 
-    def on_particle_mode_pressed(self, mode):
-        self.active_particle = mode
-        mc.set_particle_mode(mode)
-        self._sync_active_states()
-        message = "PARTICLE GAIN MUTED" if mode == PARTICLE_OFF else (
-            f"PARTICLE GAIN {mode}  •  CLICK THE 3D VIEWPORT TO BURST"
-        )
-        self.set_status(message)
+    def on_source(self, label):
+        self.active_source = label
+        if label == "OFF":
+            audio_engine.configure(AudioSourceMode.OFF)
+            director.select(None)
+            self.live_dot.color = PALETTE["line"]
+            self.live_label.text = "AUDIO OFF"
+            self.live_label.color = _rgba(PALETTE["muted"])
+            self.set_status("AUDIO ANALYSIS OFF  •  HOME GEOMETRY RESTORED")
+        else:
+            mc.set_animation_mode("")
+            self.active_animation = "NONE"
+            audio_engine.configure(
+                label,
+                system_device_id=preferences.system_device_id,
+                microphone_device_id=preferences.microphone_device_id,
+            )
+            director.select(self.active_program)
+            self.live_dot.color = PALETTE["teal"]
+            self.live_label.text = f"{self.active_program} LIVE"
+            self.live_label.color = _rgba(PALETTE["teal"])
+            self.set_status(f"{label} ANALYSIS STARTED  •  NOT RECORDING")
+        self._sync_buttons()
+        self._save()
 
-    def on_animation_pressed(self, label):
+    def on_program(self, label):
+        self.active_program = label
+        if self.active_source != "OFF":
+            director.select(label)
+            self.live_label.text = f"{label} LIVE"
+            self.set_status(f"AUDIO PROGRAM {label}  •  250 MS COHESIVE TRANSITION")
+        else:
+            self.set_status(f"{label} ARMED  •  SELECT AN AUDIO SOURCE")
+        self._sync_buttons()
+        self._save()
+
+    def on_manual_motion(self, label):
+        self.active_source = "OFF"
+        audio_engine.configure(AudioSourceMode.OFF)
+        director.select(None)
         self.active_animation = label
         mc.set_animation_mode(ANIMATION_VALUES[label])
-        self._apply_wave_value()
-        self._sync_active_states()
+        self._apply_wave()
+        self.live_dot.color = PALETTE["line"]
+        self.live_label.text = "AUDIO OFF"
+        self.live_label.color = _rgba(PALETTE["muted"])
+        self._sync_buttons()
+        self._save()
+        self.set_status(f"MANUAL MOTION {label}")
 
-        lamp_colors = {
-            "WAVE": PALETTE["teal"],
-            "SPIN": PALETTE["red"],
-            "PULSE": PALETTE["blue"],
-            "NONE": (38, 44, 47),
-        }
-        led_lamp.color = lamp_colors[label]
-        self.led_halo.color = lamp_colors[label] if label != "NONE" else PALETTE["line"]
-        self.set_status(f"MOTION PROGRAM {label}")
+    def on_particle(self, mode):
+        self.active_particle = mode
+        mc.set_particle_mode(mode)
+        self._sync_buttons()
+        self.set_status(f"PARTICLE LIMIT {mode}")
 
-    def _apply_wave_value(self):
+    def on_sensitivity(self, value):
+        global knob_wave_value
+        director.sensitivity = float(value)
+        knob_wave_value = float(value)
+        self._apply_wave()
+        self._save()
+        self.set_status(f"SENSITIVITY {value:.2f}")
+
+    def on_reactivity(self, value):
+        director.reactivity = float(value)
+        self._save()
+        self.set_status(f"REACTIVITY {value:.2f}")
+
+    def on_detail(self, value):
+        global knob_detail_value
+        knob_detail_value = float(round(value))
+        faces = 20 * (4 ** int(knob_detail_value))
+        self.set_status(f"GLOBE DETAIL {int(knob_detail_value)}  •  {faces} FACES ON NEXT ROUTE")
+
+    def on_apex(self, angle):
+        global turntable_angle
+        turntable_angle = float(angle)
+        offset = 0.18 + (turntable_angle % 360.0) / 360.0 * 0.7
+        self.set_status(f"GLOBE APEX OFFSET {offset:.2f}")
+
+    def _apply_wave(self):
         if self.active_animation not in ("WAVE", "PULSE"):
             return
         multiplier = 1.65 if self.active_animation == "PULSE" else 1.0
@@ -682,145 +567,179 @@ class SwitchboardWindow(pyglet.window.Window):
             if pyramid.physics.wave_axis_enable["y"]:
                 pyramid.physics.wave_amplitude["y"] = knob_wave_value * multiplier
 
-    def on_knob_wave_drag(self, new_value):
-        global knob_wave_value
-        knob_wave_value = float(new_value)
-        self._apply_wave_value()
-        self.set_status(f"WAVE AMPLITUDE  {knob_wave_value:.2f}", duration=2.0)
+    def cycle_system_device(self):
+        self.system_devices, self.microphone_devices = audio_engine.devices()
+        preferences.system_device_id = self._next_device(self.system_devices, preferences.system_device_id)
+        self._update_device_names()
+        if self.active_source in ("SYSTEM", "BOTH"):
+            self.on_source(self.active_source)
+        self._save()
 
-    def on_knob_subdiv_drag(self, new_value):
-        global knob_subdiv_value
-        knob_subdiv_value = float(int(round(new_value)))
-        faces = 20 * (4 ** int(knob_subdiv_value))
-        self.set_status(
-            f"GLOBE DETAIL  {int(knob_subdiv_value)}  •  {faces} FACES ON NEXT ROUTE",
-            duration=2.0,
-        )
+    def cycle_microphone_device(self):
+        self.system_devices, self.microphone_devices = audio_engine.devices()
+        preferences.microphone_device_id = self._next_device(self.microphone_devices, preferences.microphone_device_id)
+        self._update_device_names()
+        if self.active_source in ("MIC", "BOTH"):
+            self.on_source(self.active_source)
+        self._save()
 
-    def on_turntable_spin(self, angle):
-        global turntable_angle
-        turntable_angle = float(angle)
-        offset = 0.18 + (turntable_angle % 360.0) / 360.0 * 0.7
-        self.set_status(f"GLOBE APEX OFFSET  {offset:.2f}", duration=2.0)
+    @staticmethod
+    def _next_device(devices, current):
+        if not devices:
+            return None
+        ids = [item.identifier for item in devices]
+        return ids[(ids.index(current) + 1) % len(ids)] if current in ids else ids[0]
+
+    def _update_device_names(self):
+        system = next((item for item in self.system_devices if item.identifier == preferences.system_device_id), None)
+        microphone = next((item for item in self.microphone_devices if item.identifier == preferences.microphone_device_id), None)
+        if system is None and self.system_devices:
+            system = self.system_devices[0]
+            preferences.system_device_id = system.identifier
+        if microphone is None and self.microphone_devices:
+            microphone = self.microphone_devices[0]
+            preferences.microphone_device_id = microphone.identifier
+        self.system_name.text = "SYSTEM  " + _short_name(system.name if system else "NO LOOPBACK ENDPOINT")
+        self.mic_name.text = "MIC     " + _short_name(microphone.name if microphone else "NO INPUT ENDPOINT")
+
+    def toggle_reduced_motion(self):
+        director.reduced_motion = not director.reduced_motion
+        self.reduced_button.set_active(director.reduced_motion)
+        self._save()
+        self.set_status("REDUCED MOTION " + ("ON" if director.reduced_motion else "OFF"))
+
+    def update_audio_status(self, dt):
+        del dt
+        frame = audio_engine.snapshot()
+        status = audio_engine.status()
+        self.system_meter.width = int(244 * frame.system.rms)
+        self.mic_meter.width = int(244 * frame.microphone.rms)
+        self.system_meter.color = PALETTE["teal"] if frame.system.active else PALETTE["line"]
+        self.mic_meter.color = PALETTE["amber"] if frame.microphone.active else PALETTE["line"]
+        self.telemetry.text = f"{frame.capture_latency_ms:4.1f} MS  •  {frame.dropped_windows} DROPPED  •  {status['backend']}"
+        if self.active_source != "OFF":
+            system_state = status["system"].state
+            mic_state = status["microphone"].state
+            if self.active_source in ("SYSTEM", "BOTH") and system_state == "unavailable":
+                self.live_dot.color = PALETTE["red"]
+                self.live_label.text = "SYSTEM UNAVAILABLE"
+            elif self.active_source in ("MIC", "BOTH") and mic_state == "unavailable":
+                self.live_dot.color = PALETTE["red"]
+                self.live_label.text = "MIC UNAVAILABLE"
+
+    def _shutdown(self):
+        pyglet.clock.unschedule(self.update_audio_status)
+        audio_engine.shutdown()
+        pyglet.app.exit()
+
+    def on_close(self):
+        self._shutdown()
 
 
 class VisualizationWindow(pyglet.window.Window):
-    """Live 3D stage for the selected formation and its signal trace."""
+    """The dominant live canvas; wireframes rest white and react individually."""
 
     def __init__(self, width=900, height=650, title="Rainbow Starburst — 3D Signal"):
         super().__init__(width, height, title, resizable=True, vsync=True)
         self.set_minimum_size(560, 420)
         self.start_time = time.time()
-        self.draw_dist = 0.0
-        self.drawing_forward = True
-        self.draw_speed = 8.0
+        self.draw_distance = 0.0
+        self.draw_speed = 10.0
         self.camera_distance = 14.0
         self.scene_name = "Star"
         self.paused = False
-        self.cursor_world = np.zeros(3, dtype=float)
+        self.cursor_world = np.zeros(3)
         self.cursor_visible = False
-
+        self.particle_accumulator = np.zeros(len(mc.pyramids))
         rng = random.Random(86)
         self.stars = [
-            (
-                rng.uniform(-14.0, 14.0),
-                rng.uniform(-6.0, 11.0),
-                rng.uniform(-12.0, -2.0),
-                rng.uniform(0.25, 0.8),
-            )
+            (rng.uniform(-14, 14), rng.uniform(-6, 11), rng.uniform(-12, -2), rng.uniform(0.25, 0.8))
             for _ in range(120)
         ]
-
-        self.hud_batch = pyglet.graphics.Batch()
+        self.hud = pyglet.graphics.Batch()
         self.hud_brand = pyglet.text.Label(
-            "RAINBOW / STARBURST",
-            x=26,
-            y=height - 30,
-            anchor_x="left",
-            anchor_y="top",
-            font_name="Segoe UI",
-            font_size=13,
-            color=_rgba(PALETTE["cream"]),
-            batch=self.hud_batch,
+            "RAINBOW / STARBURST", x=26, y=height - 30, anchor_y="top",
+            font_name="Segoe UI", font_size=13, color=_rgba(PALETTE["cream"]), batch=self.hud,
         )
         self.hud_scene = pyglet.text.Label(
-            "",
-            x=26,
-            y=height - 55,
-            anchor_x="left",
-            anchor_y="top",
-            font_name="Consolas",
-            font_size=9,
-            color=_rgba(PALETTE["teal"]),
-            batch=self.hud_batch,
+            "", x=26, y=height - 55, anchor_y="top", font_name="Consolas",
+            font_size=9, color=_rgba(PALETTE["teal"]), batch=self.hud,
         )
         self.hud_help = pyglet.text.Label(
             "CLICK: PARTICLE BURST   •   SCROLL: CAMERA   •   SPACE: PAUSE",
-            x=26,
-            y=22,
-            anchor_x="left",
-            anchor_y="bottom",
-            font_name="Segoe UI",
-            font_size=8,
-            color=_rgba(PALETTE["muted"]),
-            batch=self.hud_batch,
+            x=26, y=22, anchor_y="bottom", font_name="Segoe UI", font_size=8,
+            color=_rgba(PALETTE["muted"]), batch=self.hud,
         )
         self._update_hud()
         pyglet.clock.schedule_interval(self.update, 1.0 / 60.0)
 
     def set_scene(self, name):
         self.scene_name = name
-        self.draw_dist = 0.0
-        self.drawing_forward = True
+        self.draw_distance = 0.0
+        self.particle_accumulator = np.zeros(len(mc.pyramids))
         self._update_hud()
 
     def _update_hud(self):
+        mode = director.active_name or (ui_window.active_animation if ui_window else "MANUAL")
+        source = ui_window.active_source if ui_window else "OFF"
         paused = "  •  PAUSED" if self.paused else ""
-        self.hud_scene.text = (
-            f"{self.scene_name.upper()}  •  {len(mc.pyramids)} PYRAMIDS"
-            f"  •  PARTICLES {mc.current_particle_mode}{paused}"
-        )
+        self.hud_scene.text = f"{self.scene_name.upper()}  •  {len(mc.pyramids)} PYRAMIDS  •  {source}/{mode}{paused}"
 
     def update(self, dt):
         if self.paused:
             return
-        dt = min(dt, 0.05)
-        current_time = time.time() - self.start_time
-        mc.update(dt, current_time)
-        self.draw_dist += self.draw_speed * dt * (1.0 if self.drawing_forward else -1.0)
+        dt = min(float(dt), 0.05)
+        now = time.time() - self.start_time
+        mc.update(dt, now)
+        state = director.update(dt, now, audio_engine.snapshot())
+        self.draw_distance += self.draw_speed * dt * (0.35 + 1.65 * state.route_energy)
+        self._emit_reactive_particles(state, dt)
         self._update_hud()
+
+    def _emit_reactive_particles(self, state, dt):
+        if not director.active or not len(state.particle_rate):
+            return
+        if len(self.particle_accumulator) != len(state.particle_rate):
+            self.particle_accumulator = np.zeros(len(state.particle_rate))
+        self.particle_accumulator += state.particle_rate * dt
+        ready = np.flatnonzero(self.particle_accumulator >= 1.0)
+        for index in ready[:12]:
+            count = min(4, int(self.particle_accumulator[index]))
+            self.particle_accumulator[index] -= count
+            path = self._display_path(int(index))
+            origin = path.mean(axis=0) if len(path) else director.topology.centers[index]
+            mc.spawn_particles(count, origin)
+
+    def _display_path(self, index):
+        if director.active and index < director.topology.count:
+            return apply_render_state(director.topology.home_paths[index], director.topology, index, director.output)
+        return np.asarray(mc.pyramids[index].get_transformed_path(), dtype=float)
 
     def on_draw(self):
         glViewport(0, 0, self.width, self.height)
-        glClearColor(0.012, 0.018, 0.028, 1.0)
+        glClearColor(0.008, 0.013, 0.021, 1.0)
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
         glEnable(GL_DEPTH_TEST)
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
         glDisable(GL_CULL_FACE)
-
         glMatrixMode(GL_PROJECTION)
         glLoadIdentity()
-        aspect = float(self.width) / max(1.0, float(self.height))
-        gluPerspective(58.0, aspect, 0.1, 100.0)
-
+        gluPerspective(58.0, float(self.width) / max(1.0, float(self.height)), 0.1, 100.0)
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()
         gluLookAt(0.0, 8.5, self.camera_distance, 0.0, 0.4, 0.0, 0.0, 1.0, 0.0)
-
         now = time.time() - self.start_time
         glRotatef(now * 8.0, 0.0, 1.0, 0.0)
-
         self.draw_starfield()
         self.draw_floor_grid()
         self.draw_pyramids()
-        self.draw_rainbow_path()
+        self.draw_signal_trace()
         self.draw_particles()
         if self.cursor_visible:
             self.draw_cursor_marker()
-
         glDisable(GL_DEPTH_TEST)
-        self.hud_batch.draw()
+        self.hud.draw()
 
     def draw_starfield(self):
         glPointSize(2.0)
@@ -843,59 +762,72 @@ class VisualizationWindow(pyglet.window.Window):
         glEnd()
 
     def draw_pyramids(self):
-        glLineWidth(1.5)
-        glColor4f(1.0, 1.0, 1.0, 0.68)
-        for pyramid in mc.pyramids:
-            path = pyramid.get_transformed_path()
+        state = director.output
+        for index in range(len(mc.pyramids)):
+            path = self._display_path(index)
             if len(path) < 2:
                 continue
+            if director.active:
+                accent = _rainbow_color(state.accent_hue[index])
+                mix = float(state.accent_mix[index])
+                color = tuple(1.0 + (channel - 1.0) * mix for channel in accent)
+                alpha = float(state.line_alpha[index])
+                width = float(state.line_width[index])
+            else:
+                color, alpha, width = (1.0, 1.0, 1.0), 0.68, 1.5
+            glLineWidth(width)
+            glColor4f(*color, alpha)
             glBegin(GL_LINE_STRIP)
             for point in path:
-                glVertex3f(float(point[0]), float(point[1]), float(point[2]))
+                glVertex3f(*point)
             glEnd()
 
-    def draw_rainbow_path(self):
-        points, total_length, distances = mc.build_global_path(
-            close_loop=False,
-            star_bridge=False,
-        )
-        if len(points) < 2 or total_length <= 1e-9:
+    def _trace_points(self):
+        if director.active:
+            if director.output.route_energy < 0.015:
+                return []
+            route = director.output.route[:96]
+            points = []
+            for index in route:
+                if 0 <= index < len(mc.pyramids):
+                    path = self._display_path(index)
+                    if len(path):
+                        if points:
+                            points.append(path[0])
+                        points.extend(path)
+            return points
+        points, _, _ = mc.build_global_path(close_loop=False, star_bridge=False)
+        return points
+
+    def draw_signal_trace(self):
+        points = self._trace_points()
+        if len(points) < 2:
             return
-
-        if self.draw_dist > total_length:
-            self.draw_dist = total_length
-            self.drawing_forward = False
-        elif self.draw_dist < 0.0:
-            self.draw_dist = 0.0
-            self.drawing_forward = True
-
-        glLineWidth(3.0)
+        lengths = np.linalg.norm(np.diff(np.asarray(points), axis=0), axis=1)
+        distances = np.concatenate(([0.0], np.cumsum(lengths)))
+        total = float(distances[-1])
+        if total <= 1e-9:
+            return
+        draw_to = self.draw_distance % total
+        alpha = 0.35 + 0.65 * (director.output.route_energy if director.active else 1.0)
+        glLineWidth(2.5 + (1.2 * director.output.route_energy if director.active else 0.5))
         glBegin(GL_LINE_STRIP)
         for index in range(len(points) - 1):
-            segment_start = distances[index]
-            segment_end = distances[index + 1]
-            if segment_start > self.draw_dist:
+            if distances[index] > draw_to:
                 break
-            point_a = points[index]
-            point_b = points[index + 1]
-
-            fraction_a = segment_start / total_length
-            glColor3f(*_rainbow_color(fraction_a))
-            glVertex3f(float(point_a[0]), float(point_a[1]), float(point_a[2]))
-
-            if segment_end <= self.draw_dist:
-                fraction_b = segment_end / total_length
-                glColor3f(*_rainbow_color(fraction_b))
-                glVertex3f(float(point_b[0]), float(point_b[1]), float(point_b[2]))
-                continue
-
-            segment_length = segment_end - segment_start
-            if segment_length > 1e-9:
-                alpha = (self.draw_dist - segment_start) / segment_length
-                midpoint = point_a + alpha * (point_b - point_a)
-                glColor3f(*_rainbow_color(self.draw_dist / total_length))
-                glVertex3f(float(midpoint[0]), float(midpoint[1]), float(midpoint[2]))
-            break
+            point_a, point_b = points[index], points[index + 1]
+            glColor4f(*_rainbow_color(distances[index] / total), alpha)
+            glVertex3f(*point_a)
+            if distances[index + 1] <= draw_to:
+                glColor4f(*_rainbow_color(distances[index + 1] / total), alpha)
+                glVertex3f(*point_b)
+            else:
+                segment = max(1e-9, distances[index + 1] - distances[index])
+                fraction = (draw_to - distances[index]) / segment
+                midpoint = point_a + fraction * (point_b - point_a)
+                glColor4f(*_rainbow_color(draw_to / total), alpha)
+                glVertex3f(*midpoint)
+                break
         glEnd()
 
     def draw_particles(self):
@@ -921,34 +853,39 @@ class VisualizationWindow(pyglet.window.Window):
         glEnd()
 
     def _screen_to_world(self, x, y):
-        normalized_x = (x / max(1.0, self.width) - 0.5) * 13.0
-        normalized_z = (y / max(1.0, self.height) - 0.5) * 10.0
-        return np.array([normalized_x, 0.35, -normalized_z], dtype=float)
+        return np.array([
+            (x / max(1.0, self.width) - 0.5) * 13.0,
+            0.35,
+            -(y / max(1.0, self.height) - 0.5) * 10.0,
+        ])
 
     def on_mouse_motion(self, x, y, dx, dy):
+        del dx, dy
         self.cursor_world = self._screen_to_world(x, y)
         self.cursor_visible = True
 
     def on_mouse_press(self, x, y, button, modifiers):
+        del modifiers
         if button == mouse.LEFT:
             self.cursor_world = self._screen_to_world(x, y)
             self.cursor_visible = True
             mc.handle_collision(self.cursor_world)
-            self._update_hud()
 
     def on_mouse_scroll(self, x, y, scroll_x, scroll_y):
+        del x, y, scroll_x
         self.camera_distance = max(7.0, min(24.0, self.camera_distance - scroll_y * 0.8))
 
     def on_key_press(self, symbol, modifiers):
+        del modifiers
         if symbol == key.SPACE:
             self.paused = not self.paused
-            self._update_hud()
         elif symbol == key.R:
             self.camera_distance = 14.0
-            self.draw_dist = 0.0
-            self.drawing_forward = True
+            self.draw_distance = 0.0
         elif symbol == key.ESCAPE:
+            audio_engine.shutdown()
             pyglet.app.exit()
+        self._update_hud()
 
     def on_resize(self, width, height):
         super().on_resize(width, height)
@@ -957,39 +894,32 @@ class VisualizationWindow(pyglet.window.Window):
 
     def on_close(self):
         pyglet.clock.unschedule(self.update)
+        audio_engine.shutdown()
         pyglet.app.exit()
 
 
 def run_gui():
-    """Launch the switchboard and its companion visualization window."""
+    """Launch the private-by-default switchboard and companion stage."""
     global ui_window, visualization_window
-
-    # A scene switch is also a programming operation: when it returns, the
-    # exported files must already match the active formation exactly.
     mc.configure_export(enabled=True, async_mode=False)
     mc.init_star_formation(subdivisions=1, core_radius=3.0, spike_height=2.4)
     mc.set_animation_mode(ANIMATION_WAVE_Y)
     for pyramid in mc.pyramids:
         pyramid.physics.wave_amplitude["y"] = knob_wave_value
-
+    director.set_formation(mc.pyramids)
     ui_window = SwitchboardWindow()
     visualization_window = VisualizationWindow()
-
     screen = ui_window.screen
-    gap = 20
+    gap = 18
     total_width = ui_window.width + visualization_window.width + gap
-    if screen.width >= total_width + 60:
-        left = max(30, (screen.width - total_width) // 2)
-        bottom = max(40, (screen.height - max(ui_window.height, visualization_window.height)) // 2)
-        ui_window.set_location(left, bottom + 15)
-        visualization_window.set_location(left + ui_window.width + gap, bottom)
+    if screen.width >= total_width + 40:
+        left = max(20, (screen.width - total_width) // 2)
+        bottom = max(24, (screen.height - max(ui_window.height, visualization_window.height)) // 2)
+        ui_window.set_location(left, bottom)
+        visualization_window.set_location(left + ui_window.width + gap, bottom + 54)
     else:
-        ui_window.set_location(30, max(30, screen.height - ui_window.height - 60))
-        visualization_window.set_location(
-            max(60, screen.width - visualization_window.width - 40),
-            40,
-        )
-
+        ui_window.set_location(24, max(24, screen.height - ui_window.height - 50))
+        visualization_window.set_location(max(45, screen.width - visualization_window.width - 30), 30)
     pyglet.app.run()
 
 

--- a/pyramidGUI.py
+++ b/pyramidGUI.py
@@ -616,7 +616,10 @@ class SwitchboardWindow(pyglet.window.Window):
         self.mic_meter.width = int(244 * frame.microphone.rms)
         self.system_meter.color = PALETTE["teal"] if frame.system.active else PALETTE["line"]
         self.mic_meter.color = PALETTE["amber"] if frame.microphone.active else PALETTE["line"]
-        self.telemetry.text = f"{frame.capture_latency_ms:4.1f} MS  •  {frame.dropped_windows} DROPPED  •  {status['backend']}"
+        self.telemetry.text = (
+            f"{frame.capture_latency_ms:4.1f} MS  •  {frame.dropped_windows} DROPPED  "
+            f"•  {len(mc.pyramids)} RESONANT VOICES"
+        )
         if self.active_source != "OFF":
             system_state = status["system"].state
             mic_state = status["microphone"].state

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 pyglet
 PyOpenGL
+PyAudioWPatch; platform_system == "Windows"

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,42 @@
+"""Small persistent preference store with privacy-preserving defaults."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+
+
+@dataclass
+class AppSettings:
+    audio_source: str = "OFF"
+    audio_program: str = "CINEMA"
+    system_device_id: str | None = None
+    microphone_device_id: str | None = None
+    sensitivity: float = 1.0
+    reactivity: float = 1.0
+    reduced_motion: bool = False
+
+
+def settings_path() -> Path:
+    root = Path(os.environ.get("LOCALAPPDATA", Path.home()), "RainbowStarburst")
+    return root / "settings.json"
+
+
+def load_settings() -> AppSettings:
+    path = settings_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        allowed = AppSettings.__dataclass_fields__
+        return AppSettings(**{key: value for key, value in data.items() if key in allowed})
+    except (OSError, ValueError, TypeError):
+        return AppSettings()
+
+
+def save_settings(settings: AppSettings) -> None:
+    path = settings_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(asdict(settings), indent=2), encoding="utf-8")
+    temporary.replace(path)

--- a/tests/test_animation_system.py
+++ b/tests/test_animation_system.py
@@ -1,0 +1,147 @@
+import contextlib
+import io
+import tempfile
+import unittest
+
+import numpy as np
+
+from animations.director import AnimationDirector, PROGRAM_NAMES
+from animations.render import apply_render_state
+from animations.signal_relay import SignalRelay
+from animations.topology import FormationTopology
+from audio.features import AudioFeatureFrame, SourceFeatures
+from mastercontroller import MasterController
+
+
+ACTIVE = SourceFeatures(
+    active=True,
+    rms=0.72,
+    peak=0.91,
+    bands=(0.9, 0.65, 0.35, 0.48, 0.55, 0.36, 0.82, 0.24),
+    centroid=0.53,
+    flux=0.86,
+    onset=True,
+    beat_phase=0.2,
+    tempo_bpm=120.0,
+    tempo_confidence=0.9,
+    stereo_balance=0.6,
+    stereo_width=0.35,
+    pitch_classes=(0.0, 0.55, 0.0, 0.0, 0.4, 0.0, 0.82, 0.0, 0.0, 0.3, 0.0, 0.0),
+    pitch_confidence=0.82,
+    octave_position=0.64,
+    spectral_flatness=0.12,
+    low_flux=0.8,
+    high_flux=0.75,
+)
+
+
+def active_frame(sequence=1):
+    return AudioFeatureFrame(sequence, sequence / 60.0, ACTIVE, SourceFeatures.silence(), 21.0, 0)
+
+
+class TopologyAndRenderTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.controller = MasterController(self.directory.name)
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.controller.init_star_formation(subdivisions=1, core_radius=3.0, spike_height=2.4)
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    def test_star_topology_is_connected_with_three_shared_edge_neighbors(self):
+        topology = FormationTopology(self.controller.pyramids)
+        self.assertTrue(topology.shared_surface)
+        self.assertEqual(topology.count, 80)
+        self.assertEqual({len(neighbors) for neighbors in topology.adjacency}, {3})
+        self.assertLess(int(topology.distances_from(0).max()), topology.count)
+
+    def test_transient_tip_motion_preserves_all_star_base_points(self):
+        director = AnimationDirector(self.controller.pyramids)
+        director.select("CROWN")
+        state = director.update(1.0, 1.0, active_frame())
+        original_paths = [path.copy() for path in director.topology.home_paths]
+        for index, original in enumerate(original_paths):
+            transformed = apply_render_state(original, director.topology, index, state)
+            np.testing.assert_allclose(transformed[:3], original[:3], atol=1e-9)
+            np.testing.assert_array_equal(director.topology.home_paths[index], original)
+
+
+class ProgramIntegrationTests(unittest.TestCase):
+    def test_every_program_is_finite_and_bounded_across_all_formations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            controller = MasterController(directory)
+            formations = (
+                lambda: controller.init_edge_to_edge_pyramids(count=7),
+                lambda: controller.init_spike_sphere_pyramids(count=24),
+                lambda: controller.init_grid_pyramids(rows=4, cols=5),
+                lambda: controller.init_star_formation(subdivisions=1),
+                lambda: controller.init_globe_icosahedron(subdivisions=2),
+            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                for make_formation in formations:
+                    make_formation()
+                    director = AnimationDirector(controller.pyramids)
+                    for program in PROGRAM_NAMES:
+                        with self.subTest(count=len(controller.pyramids), program=program):
+                            director.select(program)
+                            state = director.update(0.3, 0.3, active_frame())
+                            self.assertTrue(np.all(np.isfinite(state.apex_scale)))
+                            self.assertTrue(np.all(np.isfinite(state.radial_offset)))
+                            self.assertTrue(np.all((state.apex_scale >= 0.55) & (state.apex_scale <= 1.9)))
+                            self.assertLessEqual(float(np.max(np.abs(state.radial_offset), initial=0.0)), 0.35 * director.topology.core_radius + 1e-9)
+
+    def test_program_switch_crossfades_and_manual_none_returns_identity_immediately(self):
+        with tempfile.TemporaryDirectory() as directory, contextlib.redirect_stdout(io.StringIO()):
+            controller = MasterController(directory)
+            controller.init_star_formation(subdivisions=1)
+            director = AnimationDirector(controller.pyramids)
+            director.select("CROWN")
+            crown = director.update(0.25, 0.25, active_frame()).copy()
+            director.select("RADAR")
+            transition = director.update(0.05, 0.30, active_frame(2))
+            self.assertFalse(np.allclose(transition.apex_scale, 1.0))
+            self.assertFalse(np.allclose(transition.apex_scale, crown.apex_scale))
+            director.select(None)
+            self.assertTrue(np.allclose(director.output.apex_scale, 1.0))
+            self.assertTrue(np.allclose(director.output.radial_offset, 0.0))
+
+    def test_every_program_returns_exactly_home_after_1_5_seconds_of_silence(self):
+        with tempfile.TemporaryDirectory() as directory, contextlib.redirect_stdout(io.StringIO()):
+            controller = MasterController(directory)
+            controller.init_star_formation(subdivisions=1)
+        silence = SourceFeatures.silence()
+        for program in PROGRAM_NAMES:
+            with self.subTest(program=program):
+                director = AnimationDirector(controller.pyramids)
+                director.select(program)
+                director.update(0.25, 0.0, active_frame())
+                for tick in range(1, 91):
+                    state = director.update(
+                        1.0 / 60.0,
+                        tick / 60.0,
+                        AudioFeatureFrame(tick + 1, tick / 60.0, silence, silence),
+                    )
+                np.testing.assert_array_equal(state.apex_scale, np.ones(80))
+                np.testing.assert_array_equal(state.uniform_scale, np.ones(80))
+                np.testing.assert_array_equal(state.radial_offset, np.zeros(80))
+
+    def test_signal_relay_fixed_step_is_render_rate_independent(self):
+        with tempfile.TemporaryDirectory() as directory, contextlib.redirect_stdout(io.StringIO()):
+            controller = MasterController(directory)
+            controller.init_star_formation(subdivisions=1)
+            topology = FormationTopology(controller.pyramids)
+
+        results = []
+        for fps in (30, 60, 144):
+            relay = SignalRelay(topology)
+            frame = active_frame()
+            for tick in range(fps):
+                relay.update(1.0 / fps, tick / fps, frame)
+            results.append(relay.displacement.copy())
+        np.testing.assert_allclose(results[0], results[1], atol=1e-8)
+        np.testing.assert_allclose(results[1], results[2], atol=1e-8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_animation_system.py
+++ b/tests/test_animation_system.py
@@ -1,5 +1,6 @@
 import contextlib
 import io
+import math
 import tempfile
 import unittest
 
@@ -7,9 +8,15 @@ import numpy as np
 
 from animations.director import AnimationDirector, PROGRAM_NAMES
 from animations.render import apply_render_state
+from animations.resonance import OrganicResonatorBank
 from animations.signal_relay import SignalRelay
 from animations.topology import FormationTopology
-from audio.features import AudioFeatureFrame, SourceFeatures
+from audio.features import (
+    AudioFeatureFrame,
+    SPECTRUM_BIN_COUNT,
+    SPECTRUM_FREQUENCIES,
+    SourceFeatures,
+)
 from mastercontroller import MasterController
 
 
@@ -18,6 +25,7 @@ ACTIVE = SourceFeatures(
     rms=0.72,
     peak=0.91,
     bands=(0.9, 0.65, 0.35, 0.48, 0.55, 0.36, 0.82, 0.24),
+    spectrum=tuple(1.0 if index in (7, 22, 36) else 0.0 for index in range(SPECTRUM_BIN_COUNT)),
     centroid=0.53,
     flux=0.86,
     onset=True,
@@ -65,6 +73,71 @@ class TopologyAndRenderTests(unittest.TestCase):
             transformed = apply_render_state(original, director.topology, index, state)
             np.testing.assert_allclose(transformed[:3], original[:3], atol=1e-9)
             np.testing.assert_array_equal(director.topology.home_paths[index], original)
+
+    def test_every_star_pyramid_has_a_unique_normalized_resonance_identity(self):
+        topology = FormationTopology(self.controller.pyramids)
+        self.assertEqual(len(np.unique(topology.resonant_frequencies)), 80)
+        self.assertAlmostEqual(float(topology.resonant_frequencies.min()), 35.0)
+        self.assertAlmostEqual(float(topology.resonant_frequencies.max()), 16000.0)
+        np.testing.assert_allclose(topology.resonance_weights.sum(axis=1), 1.0)
+        self.assertGreater(len(np.unique(np.round(topology.resonance_bandwidths, 5))), 60)
+
+
+class OrganicResonanceTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        controller = MasterController(self.directory.name)
+        with contextlib.redirect_stdout(io.StringIO()):
+            controller.init_star_formation(subdivisions=1)
+        self.topology = FormationTopology(controller.pyramids)
+
+    def tearDown(self):
+        self.directory.cleanup()
+
+    @staticmethod
+    def spectral_frame(*frequencies):
+        spectrum = np.zeros(SPECTRUM_BIN_COUNT)
+        for frequency in frequencies:
+            index = int(np.argmin(np.abs(SPECTRUM_FREQUENCIES - frequency)))
+            spectrum[index] = 1.0
+        source = SourceFeatures(
+            active=True,
+            rms=0.8,
+            peak=0.9,
+            spectrum=tuple(spectrum),
+        )
+        return AudioFeatureFrame(1, 0.0, source, SourceFeatures.silence())
+
+    def settle(self, bank, frame, fps=60):
+        for tick in range(fps):
+            bank.update(1.0 / fps, (tick + 1) / fps, frame)
+
+    def test_single_tone_excites_a_local_minority_near_its_frequency(self):
+        bank = OrganicResonatorBank(self.topology)
+        self.settle(bank, self.spectral_frame(440.0))
+        strongest = int(np.argmax(bank.displacement))
+        resonant = float(self.topology.resonant_frequencies[strongest])
+        self.assertLess(abs(math.log2(resonant / 440.0)), 0.15)
+        above_half = int(np.count_nonzero(bank.displacement > bank.displacement.max() * 0.5))
+        self.assertLess(above_half, self.topology.count // 4)
+
+    def test_two_tones_create_separate_low_and_high_voice_clusters(self):
+        bank = OrganicResonatorBank(self.topology)
+        self.settle(bank, self.spectral_frame(110.0, 4000.0))
+        strongest = np.argsort(bank.displacement)[-16:]
+        frequencies = self.topology.resonant_frequencies[strongest]
+        self.assertTrue(np.any((frequencies > 70.0) & (frequencies < 180.0)))
+        self.assertTrue(np.any((frequencies > 2800.0) & (frequencies < 5600.0)))
+
+    def test_resonator_motion_is_equivalent_across_render_rates(self):
+        results = []
+        frame = self.spectral_frame(1000.0)
+        for fps in (30, 60, 144):
+            bank = OrganicResonatorBank(self.topology)
+            self.settle(bank, frame, fps=fps)
+            results.append(bank.displacement.copy())
+        np.testing.assert_allclose(results[0], results[1], atol=0.001)
+        np.testing.assert_allclose(results[1], results[2], atol=0.001)
 
 
 class ProgramIntegrationTests(unittest.TestCase):

--- a/tests/test_audio_features.py
+++ b/tests/test_audio_features.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 from audio.engine import AudioEngine, AudioSourceMode
-from audio.features import FeatureAnalyzer
+from audio.features import FeatureAnalyzer, SPECTRUM_FREQUENCIES
 from audio.ring_buffer import AudioRingBuffer
 
 
@@ -43,6 +43,16 @@ class FeatureAnalyzerTests(unittest.TestCase):
                 feature = analyze_tone(frequency)
                 self.assertEqual(int(np.argmax(feature.bands)), band)
                 self.assertGreater(feature.bands[band], 0.14)
+
+    def test_fine_spectrum_tracks_tones_to_within_one_third_octave(self):
+        for frequency in (50, 110, 440, 1000, 4000, 10000):
+            with self.subTest(frequency=frequency):
+                feature = analyze_tone(frequency)
+                peak_frequency = float(
+                    SPECTRUM_FREQUENCIES[int(np.argmax(feature.spectrum))]
+                )
+                octave_error = abs(math.log2(peak_frequency / frequency))
+                self.assertLessEqual(octave_error, 0.43)
 
     def test_stereo_balance_reports_left_center_and_right_only(self):
         rate, hop = 48000, 512

--- a/tests/test_audio_features.py
+++ b/tests/test_audio_features.py
@@ -1,0 +1,117 @@
+import math
+import time
+import unittest
+
+import numpy as np
+
+from audio.engine import AudioEngine, AudioSourceMode
+from audio.features import FeatureAnalyzer
+from audio.ring_buffer import AudioRingBuffer
+
+
+def analyze_tone(frequency, amplitude=0.4, channels=1, seconds=0.45):
+    rate, hop = 48000, 512
+    analyzer = FeatureAnalyzer(rate, channels)
+    output = None
+    frame_count = int(seconds * rate / hop)
+    for block in range(frame_count):
+        t = (np.arange(hop) + block * hop) / rate
+        signal = amplitude * np.sin(2.0 * math.pi * frequency * t)
+        frames = signal[:, None]
+        if channels == 2:
+            frames = np.column_stack((signal, signal))
+        output = analyzer.push(frames.astype(np.float32), block * hop / rate)
+    return output
+
+
+class RingBufferTests(unittest.TestCase):
+    def test_overflow_discards_oldest_frames_without_changing_shape(self):
+        ring = AudioRingBuffer(5, 2)
+        ring.write(np.arange(8, dtype=np.float32).reshape(4, 2))
+        ring.write(np.arange(8, 16, dtype=np.float32).reshape(4, 2))
+        result = ring.read(10)
+        self.assertEqual(result.shape, (5, 2))
+        np.testing.assert_array_equal(result, np.arange(6, 16, dtype=np.float32).reshape(5, 2))
+        self.assertEqual(ring.dropped_frames, 3)
+
+
+class FeatureAnalyzerTests(unittest.TestCase):
+    def test_generated_sines_select_the_documented_log_band(self):
+        expected = {50: 0, 100: 0, 250: 2, 500: 3, 1000: 4, 2500: 5, 4000: 6, 10000: 7}
+        for frequency, band in expected.items():
+            with self.subTest(frequency=frequency):
+                feature = analyze_tone(frequency)
+                self.assertEqual(int(np.argmax(feature.bands)), band)
+                self.assertGreater(feature.bands[band], 0.14)
+
+    def test_stereo_balance_reports_left_center_and_right_only(self):
+        rate, hop = 48000, 512
+        for left_gain, right_gain, expected in ((1, 0, -1), (1, 1, 0), (0, 1, 1)):
+            analyzer = FeatureAnalyzer(rate, 2)
+            feature = None
+            for block in range(12):
+                t = (np.arange(hop) + block * hop) / rate
+                tone = 0.4 * np.sin(2 * math.pi * 400 * t)
+                feature = analyzer.push(np.column_stack((tone * left_gain, tone * right_gain)), block * hop / rate)
+            self.assertAlmostEqual(feature.stereo_balance, expected, delta=0.08)
+
+    def test_pitch_class_matches_across_octaves(self):
+        a4 = analyze_tone(440.0)
+        a5 = analyze_tone(880.0)
+        self.assertEqual(int(np.argmax(a4.pitch_classes)), 9)
+        self.assertEqual(int(np.argmax(a5.pitch_classes)), 9)
+        self.assertGreater(a5.octave_position, a4.octave_position)
+
+    def test_onset_refractory_prevents_duplicate_events(self):
+        analyzer = FeatureAnalyzer(48000, 1)
+        silence = np.zeros((1024, 1), dtype=np.float32)
+        for index in range(5):
+            analyzer.analyze(silence, index * 0.02)
+        impulse = silence.copy()
+        impulse[120:180, 0] = np.hanning(60).astype(np.float32)
+        first = analyzer.analyze(impulse, 0.12)
+        second = analyzer.analyze(impulse, 0.16)
+        self.assertTrue(first.onset)
+        self.assertFalse(second.onset)
+
+    def test_steady_clicks_lock_tempo_within_four_beats(self):
+        analyzer = FeatureAnalyzer(48000, 1)
+        for onset_time in (0.0, 0.5, 1.0, 1.5):
+            analyzer._onset_times.append(onset_time)
+        tempo, confidence, phase = analyzer._tempo(1.5)
+        self.assertAlmostEqual(tempo, 120.0, delta=0.5)
+        self.assertGreater(confidence, 0.65)
+        self.assertAlmostEqual(phase, 0.0, delta=0.01)
+        _, stale_confidence, _ = analyzer._tempo(4.1)
+        self.assertEqual(stale_confidence, 0.0)
+
+    def test_white_noise_has_low_pitch_class_confidence(self):
+        rng = np.random.default_rng(86)
+        analyzer = FeatureAnalyzer(48000, 1)
+        feature = None
+        for block in range(20):
+            noise = rng.normal(0.0, 0.2, 512).astype(np.float32)
+            feature = analyzer.push(noise[:, None], block * 512 / 48000)
+        self.assertLess(feature.pitch_confidence, 0.2)
+
+
+class SimulatedEngineTests(unittest.TestCase):
+    def test_demo_source_publishes_bounded_features_and_stops(self):
+        engine = AudioEngine()
+        try:
+            engine.configure(AudioSourceMode.DEMO)
+            deadline = time.monotonic() + 1.5
+            frame = engine.snapshot()
+            while frame.sequence == 0 and time.monotonic() < deadline:
+                time.sleep(0.02)
+                frame = engine.snapshot()
+            self.assertGreater(frame.sequence, 0)
+            self.assertTrue(all(0.0 <= value <= 1.0 for value in frame.system.bands))
+            self.assertEqual(engine.status()["system"].state, "demo")
+        finally:
+            engine.shutdown()
+        self.assertEqual(engine.mode, AudioSourceMode.OFF)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_geometry_and_exports.py
+++ b/tests/test_geometry_and_exports.py
@@ -1,0 +1,133 @@
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from mastercontroller import (
+    MAX_GLOBE_SUBDIVISIONS,
+    MasterController,
+    generate_icosahedron_faces,
+)
+from pyramid import Pyramid
+
+
+def transformed_apex_direction(pyramid):
+    local_apex = np.array([0.0, pyramid.apex_height, 0.0], dtype=float)
+    transformed = Pyramid.transform_path(
+        [local_apex], pyramid.physics.position, pyramid.physics.rotation
+    )[0]
+    direction = transformed - pyramid.physics.position
+    return direction / np.linalg.norm(direction)
+
+
+class GeometryTests(unittest.TestCase):
+    def test_globe_subdivision_is_bounded(self):
+        maximum_faces = 20 * (4 ** MAX_GLOBE_SUBDIVISIONS)
+        self.assertEqual(len(generate_icosahedron_faces(99)), maximum_faces)
+        self.assertEqual(len(generate_icosahedron_faces(-4)), 20)
+
+    def test_spike_sphere_apexes_point_outward_and_positions_stay_fixed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            controller = MasterController(export_directory=directory)
+            with contextlib.redirect_stdout(io.StringIO()):
+                controller.init_spike_sphere_pyramids(count=32, sphere_radius=4.0)
+
+            original_positions = [p.physics.position.copy() for p in controller.pyramids]
+            for pyramid in controller.pyramids:
+                radial = pyramid.physics.position / np.linalg.norm(pyramid.physics.position)
+                self.assertGreater(np.dot(transformed_apex_direction(pyramid), radial), 0.999)
+                self.assertEqual(pyramid.physics.gravity, 0.0)
+
+            controller.update(0.5, 0.5)
+            for pyramid, original in zip(controller.pyramids, original_positions):
+                np.testing.assert_allclose(pyramid.physics.position, original)
+
+    def test_star_is_a_closed_edge_sharing_spike_sphere(self):
+        with tempfile.TemporaryDirectory() as directory:
+            controller = MasterController(export_directory=directory)
+            with contextlib.redirect_stdout(io.StringIO()):
+                controller.init_star_formation(
+                    subdivisions=1, core_radius=3.0, spike_height=2.4
+                )
+
+            self.assertEqual(len(controller.pyramids), 80)
+            edge_counts = {}
+            for pyramid in controller.pyramids:
+                base = pyramid.local_path[:3]
+                for first, second in ((base[0], base[1]), (base[1], base[2]), (base[2], base[0])):
+                    endpoints = sorted(
+                        (tuple(np.round(first, 8)), tuple(np.round(second, 8)))
+                    )
+                    edge = tuple(endpoints)
+                    edge_counts[edge] = edge_counts.get(edge, 0) + 1
+
+                face_center = sum(base) / 3.0
+                face_normal = face_center / np.linalg.norm(face_center)
+                apex = pyramid.local_path[4]
+                apex_direction = apex / np.linalg.norm(apex)
+                self.assertGreater(np.dot(apex_direction, face_normal), 0.999)
+                self.assertGreater(np.linalg.norm(apex), 3.0)
+
+            self.assertTrue(edge_counts)
+            self.assertEqual(set(edge_counts.values()), {2})
+
+    def test_wave_is_visual_offset_not_position_drift(self):
+        pyramid = Pyramid()
+        pyramid.physics.gravity = 0.0
+        pyramid.physics.wave_axis_enable["y"] = True
+        original = pyramid.physics.position.copy()
+
+        for frame in range(600):
+            pyramid.update(1.0 / 60.0, frame / 60.0)
+
+        np.testing.assert_allclose(pyramid.physics.position, original)
+        self.assertLessEqual(abs(pyramid.physics.wave_offset[1]), 0.5)
+
+
+class ExportSynchronizationTests(unittest.TestCase):
+    def managed_ids(self, directory):
+        return {
+            int(path.stem.removeprefix("pyramid_"))
+            for path in Path(directory).glob("pyramid_*.txt")
+            if path.stem.removeprefix("pyramid_").isdigit()
+        }
+
+    def test_exports_mirror_each_active_formation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            sentinel = Path(directory, "notes.txt")
+            sentinel.write_text("preserve me", encoding="utf-8")
+            similarly_named = Path(directory, "pyramid_draft.txt")
+            similarly_named.write_text("preserve me too", encoding="utf-8")
+
+            controller = MasterController(export_directory=directory)
+            with contextlib.redirect_stdout(io.StringIO()):
+                controller.init_edge_to_edge_pyramids(count=7)
+                self.assertEqual(self.managed_ids(directory), set(range(1, 8)))
+
+                controller.init_spike_sphere_pyramids(count=24)
+                self.assertEqual(self.managed_ids(directory), set(range(1, 25)))
+
+                controller.init_grid_pyramids(rows=4, cols=5)
+                self.assertEqual(self.managed_ids(directory), set(range(1, 21)))
+
+                controller.init_globe_icosahedron(subdivisions=1)
+                self.assertEqual(self.managed_ids(directory), set(range(1, 81)))
+
+                controller.init_star_formation(subdivisions=1)
+                self.assertEqual(self.managed_ids(directory), set(range(1, 81)))
+
+                controller.init_grid_pyramids(rows=2, cols=3)
+                self.assertEqual(self.managed_ids(directory), set(range(1, 7)))
+
+                controller.clear_pyramids()
+                self.assertEqual(self.managed_ids(directory), set())
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve me")
+            self.assertEqual(similarly_named.read_text(encoding="utf-8"), "preserve me too")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- restores the two-window experience and full 80-pyramid joined Star with edge-sharing triangular bases
- preserves stable formation/export behavior, white resting wireframes, and rainbow signal traversal
- adds local WASAPI loopback, microphone, dual-source, OFF, and deterministic DEMO inputs
- analyzes independent streams for normalized levels, eight macro FFT bands, a 48-channel logarithmic spectrum, centroid, flux/onsets, beat phase/confidence, stereo balance/width, pitch classes, octave position, and spectral flatness
- gives every generated pyramid a unique 35 Hz–16 kHz resonant center, bandwidth, harmonic/subharmonic sensitivity, response rate, damping ratio, phase, and shared-edge coupling
- composes the organic fixed-step resonator bank beneath Spectrum Crown, Beat Bloom, Conversation Orbit, Cinematic Weather, Game Radar, Signal Relay, and Harmonic Aurora
- adds immutable topology and bounded per-pyramid render state with reduced motion, 250 ms transitions, and exact 1.5-second silence reset
- adds switchboard source/program/response/device/privacy/telemetry controls while retaining WAVE/SPIN/PULSE/NONE
- keeps raw samples in bounded memory only: no recording, transcription, networking, or unsynchronized PCM mixing

## Why

The geometry and export regressions prevented the intended joined Star from operating correctly. The first audio pass still exposed only eight coarse spectral drivers, which made groups of pyramids move too much like an equalizer. The fine spectral field and individualized resonators let a tone excite a local minority, chords create multiple clusters, and broadband material spread organically while preserving authored geometry.

## User and developer impact

- System audio, microphone, both, or a private demo source can drive individual pyramids locally.
- Every pyramid has its own deterministic acoustic and mechanical personality.
- Every program has distinct macro behavior plus shared organic micro-motion.
- Manual motion immediately stops audio and restores home state.
- Endpoint loss is visible and retried without closing or blocking the renderer.
- Capture, analysis, resonators, programs, topology, and rendering are isolated and deterministic.

## Validation

- `python -m ruff check audio animations settings.py pyramidGUI.py tests`
- `python -m compileall -q audio animations mastercontroller.py pyramid.py pyramidGUI.py settings.py`
- `python -m unittest discover -s tests -v` — 24 tests passing
- `git diff --check`
- 440 Hz locality: strongest Star resonator ~452 Hz; 12/80 voices above half-strength
- 110 Hz + 4 kHz fixture: separate low/high voice clusters
- resonator equivalence validated at 30, 60, and 144 FPS
- real simultaneous WASAPI loopback + microphone run: 255 analyzed frames, about 23 ms latency, zero drops
- live Windows build responsive with zero stderr
- 1,280 individualized voices: all programs remain under roughly 1.1 ms of animation work per frame
- accelerated ten-minute Relay stress: 36,000 frames, exact reset, zero NaNs/drift, about 335 KiB retained/peak traced allocation
- exact formation/export coverage remains intact
